### PR TITLE
modify govc command for vsphere ops man deploy

### DIFF
--- a/tasks/deploy-opsman-vm/task.sh
+++ b/tasks/deploy-opsman-vm/task.sh
@@ -58,8 +58,8 @@ EOF
   cat ./opsman_settings.json
 
   echo "Importing OVA of new OpsMgr VM..."
-  echo "Running govc import.ova -options=opsman_settings.json -name=${OPSMAN_NAME} -k=true -u=${GOVC_URL} -ds=${GOVC_DATASTORE} -dc=${GOVC_DATACENTER} -pool=${GOVC_RESOURCE_POOL} -folder=/${GOVC_DATACENTER}/${OPSMAN_VM_FOLDER} ${OPSMAN_PATH}"
-  ./${CMD_PATH} import.ova -options=opsman_settings.json -name=${OPSMAN_NAME} -k=true -u=${GOVC_URL} -ds=${GOVC_DATASTORE} -dc=${GOVC_DATACENTER} -pool=${GOVC_RESOURCE_POOL} -folder=/${GOVC_DATACENTER}/${OPSMAN_VM_FOLDER} ${OPSMAN_PATH}
+  echo "Running govc import.ova -options=opsman_settings.json -name=${OPSMAN_NAME} -k=true -folder=/${GOVC_DATACENTER}/${OPSMAN_VM_FOLDER} ${OPSMAN_PATH}"
+  ./${CMD_PATH} import.ova -options=opsman_settings.json -name=${OPSMAN_NAME} -k=true -folder=/${GOVC_DATACENTER}/${OPSMAN_VM_FOLDER} ${OPSMAN_PATH}
   #
   # echo "Setting CPUs on new OpsMgr VM... /${GOVC_DATACENTER}/${OPSMAN_VM_FOLDER}/${OPSMAN_NAME}"
   ./${CMD_PATH} vm.change -c=2 -k=true -vm /${GOVC_DATACENTER}/${OPSMAN_VM_FOLDER}/${OPSMAN_NAME}

--- a/upgrade-ops-manager/README.md
+++ b/upgrade-ops-manager/README.md
@@ -28,4 +28,4 @@ of tiles installed this setting could need to be as big as 50G. In a future rele
 
     properties:
           garden:
-            garden.btrfs_store_size_mb: 
+            btrfs_store_size_mb: 


### PR DESCRIPTION
After modifying the pcf-pipelines/tasks/deploy-opsman-vm/task.sh file govc deploy for ops man upgrade completes successfully. 

![image](https://cloud.githubusercontent.com/assets/2275490/23293395/20ba46ce-fa23-11e6-9637-f15bba4e24a7.png)
