### PR TITLE
Update GitHub User for stemcell-downloader

### DIFF
--- a/upgrade-ert/pipeline.yml
+++ b/upgrade-ert/pipeline.yml
@@ -61,7 +61,7 @@ resources:
 - name: stemcell-downloader
   type: github-release
   source:
-    user: c0-ops
+    user: pivotal-cf
     repository: pcf-product-stemcell-downloader
     access_token: {{github_token}}
     globs:

--- a/upgrade-tile/params.yml
+++ b/upgrade-tile/params.yml
@@ -38,7 +38,7 @@ opsman_timeout_seconds: CHANGEME
 # The token used to download the stemcell downloader from GitHub.
 github_token: CHANGEME
 # The IaaS name for which stemcell to download. See
-# https://github.com/c0-ops/pcf-product-stemcell-downloader/ for the list of
+# https://github.com/pivotal-cf/pcf-product-stemcell-downloader/ for the list of
 # allowed IaaS names.
 iaas_type: CHANGEME
 # The interval to check Pivotal Network for updates to the product file.

--- a/upgrade-tile/pipeline.yml
+++ b/upgrade-tile/pipeline.yml
@@ -58,7 +58,7 @@ resources:
 - name: stemcell-downloader
   type: github-release
   source:
-    user: c0-ops
+    user: pivotal-cf
     repository: pcf-product-stemcell-downloader
     access_token: {{github_token}}
     globs:


### PR DESCRIPTION
The [pcf-product-stemcell-downloader](https://github.com/pivotal-cf/pcf-product-stemcell-downloader) repo is redirected from c0-ops to pivotal-cf. This causes a problem with the Concourse [github-release resource](https://github.com/concourse/github-release-resource), which does not follow the redirect. To remedy this, I updated the GitHub user in this project to match the new location of pcf-product-stemcell-downloader.