### PR TITLE
Elastic Runtime Version Parameter

### DIFF
--- a/upgrade-ert/params.yml
+++ b/upgrade-ert/params.yml
@@ -20,3 +20,4 @@ github_token: yyyyyyyyyyyyyyyyy
 iaas_type: gcp
 pivnet_poll_interval: 1h
 opsman_timeout_seconds: 300
+major_minor_version: 1.9.*

--- a/upgrade-ert/pipeline.yml
+++ b/upgrade-ert/pipeline.yml
@@ -44,7 +44,7 @@ resources:
   source:
     api_token: {{pivnet_token}}
     product_slug: elastic-runtime
-    product_version: 1.9.*
+    product_version: {{major_minor_version}}
     sort_by: semver
 
 - name: stemcell-downloader


### PR DESCRIPTION
Previously, the Elastic Runtime `product_version` field was hard-coded to `1.9.*`.  This means that in order to upgrade any other version, the pipeline must be modified, rather than just the `params.yml`  This change updates the pipeline and `params.yml` in order to make this a configurable parameter.  It
also sets the default to the previous version of `1.9.*`.