### PR TITLE
Modify Service Network config

### DIFF
--- a/tasks/config-opsdir/task.sh
+++ b/tasks/config-opsdir/task.sh
@@ -92,7 +92,7 @@ NETWORK_CONFIGURATION=$(cat <<-EOF
     },
     {
       "name": "$SERVICES_NETWORK_NAME",
-      "service_network": true,
+      "service_network": false,
       "subnets": [
         {
           "iaas_identifier": "$SERVICES_VCENTER_NETWORK",


### PR DESCRIPTION
The service network should be used for none dynamic services. If this value is set to true you can not put regular service tiles on the network as should be allowed I believe. The Dynamic service network is the one that should be checked true as a service network bosh does not control.