### PR TITLE
issue #25 fix: pivnet-cli resource glob typo

### DIFF
--- a/install-pcf/vsphere/pipeline.yml
+++ b/install-pcf/vsphere/pipeline.yml
@@ -210,7 +210,7 @@ jobs:
       params: {globs: ["*linux*"]}
       passed: [opsman-apply-changes]
     - get: pivnet-cli
-      params: {globs: ["*linux_amd64*"]}
+      params: {globs: ["*linux-amd64*"]}
 
   - task: upload-er-tile
     file: pcf-pipelines/tasks/upload-product-and-stemcell/task.yml


### PR DESCRIPTION
Fixes the `pivnet-cli` resource for the `upload-elastic-runtime-tile` job.