### PR TITLE
Fixed azure opsman cliaas config.yml

### DIFF
--- a/tasks/create-cliaas-config-azure/task.sh
+++ b/tasks/create-cliaas-config-azure/task.sh
@@ -20,13 +20,13 @@ VHD_IMAGE_URL=$(grep ${AZURE_REGION} pivnet-opsmgr/*Azure.yml | awk '{split($0, 
 
 cat > cliaas-config/config.yml <<EOF
 azure:
-  vhd_image_url: {{$VHD_IMAGE_URL}}
-  subscription_id: {{$AZURE_SUBSCRIPTION_ID}}
-  client_id: {{$AZURE_CLIENT_ID}}
-  client_secret: {{$AZURE_CLIENT_SECRET}}
-  tenant_id: {{$AZURE_TENANT_ID}}
-  resource_group_name: {{$AZURE_RESOURCE_GROUP_NAME}}
-  storage_account_name: {{$AZURE_STORAGE_ACCOUNT_NAME}}
-  storage_account_key: {{$AZURE_STORAGE_ACCOUNT_KEY}}
-  storage_container_name: {{$AZURE_STORAGE_CONTAINER_NAME}}
+  vhd_image_url: ${$VHD_IMAGE_URL}
+  subscription_id: ${$AZURE_SUBSCRIPTION_ID}
+  client_id: ${AZURE_CLIENT_ID}
+  client_secret: ${$AZURE_CLIENT_SECRET}
+  tenant_id: ${$AZURE_TENANT_ID}
+  resource_group_name: ${$AZURE_RESOURCE_GROUP_NAME}
+  storage_account_name: ${$AZURE_STORAGE_ACCOUNT_NAME}
+  storage_account_key: ${$AZURE_STORAGE_ACCOUNT_KEY}
+  storage_container_name: ${$AZURE_STORAGE_CONTAINER_NAME}
 EOF

--- a/tasks/create-cliaas-config-azure/task.sh
+++ b/tasks/create-cliaas-config-azure/task.sh
@@ -20,13 +20,13 @@ VHD_IMAGE_URL=$(grep ${AZURE_REGION} pivnet-opsmgr/*Azure.yml | awk '{split($0, 
 
 cat > cliaas-config/config.yml <<EOF
 azure:
-  vhd_image_url: ${$VHD_IMAGE_URL}
-  subscription_id: ${$AZURE_SUBSCRIPTION_ID}
+  vhd_image_url: ${VHD_IMAGE_URL}
+  subscription_id: ${AZURE_SUBSCRIPTION_ID}
   client_id: ${AZURE_CLIENT_ID}
-  client_secret: ${$AZURE_CLIENT_SECRET}
-  tenant_id: ${$AZURE_TENANT_ID}
-  resource_group_name: ${$AZURE_RESOURCE_GROUP_NAME}
-  storage_account_name: ${$AZURE_STORAGE_ACCOUNT_NAME}
-  storage_account_key: ${$AZURE_STORAGE_ACCOUNT_KEY}
-  storage_container_name: ${$AZURE_STORAGE_CONTAINER_NAME}
+  client_secret: ${AZURE_CLIENT_SECRET}
+  tenant_id: ${AZURE_TENANT_ID}
+  resource_group_name: ${AZURE_RESOURCE_GROUP_NAME}
+  storage_account_name: ${AZURE_STORAGE_ACCOUNT_NAME}
+  storage_account_key: ${AZURE_STORAGE_ACCOUNT_KEY}
+  storage_container_name: ${AZURE_STORAGE_CONTAINER_NAME}
 EOF


### PR DESCRIPTION
This fixes the error:
```
replace-opsman-vm
2017/05/01 17:32:11 failed to unmarshal config: yaml: unmarshal errors:
  line 2: cannot unmarshal !!map into string
  line 3: cannot unmarshal !!map into string
  line 4: cannot unmarshal !!map into string
  line 5: cannot unmarshal !!map into string
  line 6: cannot unmarshal !!map into string
  line 7: cannot unmarshal !!map into string
  line 8: cannot unmarshal !!map into string
  line 9: cannot unmarshal !!map into string
  line 10: cannot unmarshal !!map into string
```