### PR TITLE
Added notes to the parameter names for different upgrade pipelines

### DIFF
--- a/upgrade-buildpacks/params.yml
+++ b/upgrade-buildpacks/params.yml
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Interval to check on new releases from Pivotal Network
+# eg. 2h, 3h45m, 3000s
 pivnet_poll_interval: 1h
 
+# Pivotal Net Token to download binaries from https://network.pivotal.io
 pivnet_token: CHANGEME
+
+# Cloud Controller url and credentials - should have admin privileges
 cf_api_uri: CHANGEME
 cf_user: CHANGEME
 cf_password: CHANGEME
+
+# A github access key to download github binary releases E.g. https://github.com/pivotal-cf/om
 github_token: CHANGEME

--- a/upgrade-ert/params.yml
+++ b/upgrade-ert/params.yml
@@ -12,11 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Pivotal Net Token to download binaries from https://network.pivotal.io
 pivnet_token: CHANGEME
+
+# Ops Manager Admin Credentials - set during the installation of Ops Manager
 opsman_admin_username: CHANGEME
 opsman_admin_password: CHANGEME
+
+# Ops Manager Url
+# eg. https://myopsman.mydomain.com
 opsman_uri: CHANGEME
+
+# A github access key to download github binary releases E.g. https://github.com/pivotal-cf/om
 github_token: yyyyyyyyyyyyyyyyy
+
+# The IaaS name for which stemcell to download. See
+# https://github.com/pivotal-cf/pcf-product-stemcell-downloader/ for the list of
+# allowed IaaS names.
 iaas_type: gcp
+
+# Interval to check on new releases from Pivotal Network
+# eg. 2h, 3h45m, 3000s
 pivnet_poll_interval: 1h
 opsman_timeout_seconds: 300

--- a/upgrade-ops-manager/aws/params.yml
+++ b/upgrade-ops-manager/aws/params.yml
@@ -14,22 +14,41 @@
 
 # Resource configuration
 
+# Interval to check on new releases from Pivotal Network
+# eg. 2h, 3h45m, 3000s
 check_new_opsman_every: CHANGEME
+
+# A github access key to download github binary releases E.g. https://github.com/pivotal-cf/om
 github_token: CHANGEME
+
+# Ops Manager version to check 
+# eg. 1\.10\..*
 opsman_major_minor_version: CHANGEME
+
+# Pivotal Net Token to download Ops Manager binaries from https://network.pivotal.io
 pivnet_token: CHANGEME
 
 # Task configuration
 
+# AWS Credentials
 aws_access_key_id: CHANGEME
 aws_secret_access_key: CHANGEME
 aws_region: CHANGEME
 aws_vpc_id: CHANGEME
 
+# Existing Ops Manager VM Name Pattern. This should uniquely filter to a running Ops Manager instance.
+# eg.  myenv-OpsMan
 existing_opsman_vm_name: CHANGEME
 
+# Ops Manager Admin Credentials - set during the installation of Ops Manager
 opsman_admin_password: CHANGEME
 opsman_admin_username: CHANGEME
+
+# If install pipeline has been used then the passphrase is same as the admin password
 opsman_passphrase: CHANGEME
+
 opsman_timeout_seconds: 1200
+
+# Ops Manager Url
+# eg. https://myopsman.mydomain.com
 opsman_uri: CHANGEME

--- a/upgrade-tile/params.yml
+++ b/upgrade-tile/params.yml
@@ -40,7 +40,9 @@ github_token: CHANGEME
 # https://github.com/pivotal-cf/pcf-product-stemcell-downloader/ for the list of
 # allowed IaaS names.
 iaas_type: CHANGEME
-# The interval to check Pivotal Network for updates to the product file.
+
+# Interval to check on new releases from Pivotal Network
+# eg. 2h, 3h45m, 3000s
 pivnet_poll_interval: 1h
 # The basename of the metadata file for the product without the file extension.
 # This will be used for figuring out which stemcell the product needs.


### PR DESCRIPTION
Added comments around the different parameter names - some of them tend to be little confusing for eg, the format of `check_new_opsman_every`, these are now clarified through a few examples.