### PR TITLE
Update deploy-opsman-vm to use OPSMAN_URI

### DIFF
--- a/tasks/deploy-opsman-vm/task.sh
+++ b/tasks/deploy-opsman-vm/task.sh
@@ -89,7 +89,7 @@ EOF
         echo "...VM is running! $OUTPUT"
         timeout=$((SECONDS+${OPSMAN_TIMEOUT}))
         while [[ $started ]]; do
-          HTTP_OUTPUT=$(curl --write-out %{http_code} --silent --output /dev/null ${OPSMAN_IP})
+          HTTP_OUTPUT=$(curl --write-out %{http_code} --silent --output /dev/null ${OPSMAN_URI} -k)
           if [[ $HTTP_OUTPUT == *"302"* || $HTTP_OUTPUT == *"301"* ]]; then
             echo "Site is started! $OUTPUT >>> $HTTP_OUTPUT"
             exit 0

--- a/upgrade-ops-manager/vsphere/pipeline.yml
+++ b/upgrade-ops-manager/vsphere/pipeline.yml
@@ -124,6 +124,7 @@ jobs:
       GOVC_DATASTORE: {{vcenter_datastore}}
       GOVC_URL: {{vcenter_url}}
       OPSMAN_IP: {{opsman_ip}}
+      OPSMAN_URI: {{opsman_uri}}
       NETMASK: {{netmask}}
       GATEWAY: {{gateway}}
       DNS: {{dns}}


### PR DESCRIPTION
Update deploy-opsman-vm to use OPSMAN_URI instead of OPSMAN_IP when checking if new OpsMan web server is up and running. This makes the pipeline work for all customers, including the ones where the OpsMan domain name is NAT'ed and its VM IP address is not reachable from Concourse worker containers.