### PR TITLE
Change version parsing method to match all tiles files, which current…

### DIFF
--- a/tasks/stage-product/task.sh
+++ b/tasks/stage-product/task.sh
@@ -24,7 +24,7 @@ function main() {
 
   local version
   pushd "${cwd}/pivnet-product"
-    version="$(ls -1 *.pivotal | sed "s/"${PRODUCT_NAME}"-\(.*\).pivotal/\1/")"
+     version="$(unzip -p *.pivotal 'metadata/*.yml' | grep 'product_version:' | cut -d ':' -f 2 | tr -d ' ' | tr -d "'")"
   popd
 
   ./${CMD_PATH} --target "${OPSMAN_URI}" \


### PR DESCRIPTION
For some tiles, like SSO, New Relic and JMX, the `stage-product` task fails.
The reason is, the method used to parse the `version` variable assumes that all .pivotal files have a certain file name structure with a `-` right before the version number.
That is not the case for several tiles on PivNet.
This PR changes the method to parse the `version` information of the tile by introspecting into the metadata.yml file of the tile and extracting the `product-version:` information from it, which is supposed to work for all tiles on PivNet.