### PR TITLE
Add operations for using artifactory

### DIFF
--- a/operations/upgrade-ert-use-artifactory.yml
+++ b/operations/upgrade-ert-use-artifactory.yml
@@ -1,0 +1,20 @@
+---
+- op: replace
+  path: /resources/name=elastic-runtime
+  value:
+    name: elastic-runtime
+    type: artifactory
+    source:
+      endpoint: {{artifactory_endpoint}}
+      repository: {{artifactory_repository}}
+      regex: 'cf-(?<version>.*)\.pivotal'
+      username: {{artifactory_username}}
+      password: {{artifactory_password}}
+      skip_ssl_verification: true
+- op: add
+  path: /resource_types/-
+  value:
+    name: artifactory
+    type: docker-image
+    source:
+      repository: pivotalservices/artifactory-resource

--- a/operations/upgrade-tile-use-artifactory.yml
+++ b/operations/upgrade-tile-use-artifactory.yml
@@ -1,0 +1,20 @@
+---
+- op: replace
+  path: /resources/name={{resource_name}}
+  value:
+    name: {{resource_name}}
+    type: artifactory
+    source:
+      endpoint: {{artifactory_endpoint}}
+      repository: {{artifactory_repository}}
+      regex: {{artifactory_regex}} 
+      username: {{artifactory_username}}
+      password: {{artifactory_password}}
+      skip_ssl_verification: true
+- op: add 
+  path: /resource_types/-
+  value:
+    name: artifactory
+    type: docker-image
+    source:
+      repository: pivotalservices/artifactory-resource


### PR DESCRIPTION
These yaml patch files change the pipelines to pull the pivnet products from artifactory instead of directly from pivnet and facilitate a promotion process by migrating artifacts from lower repos to higher.