### PR TITLE
Properties for SSO tab and inclusion of sql_instance_ip

### DIFF
--- a/tasks/install-ert/configure-ert.sh
+++ b/tasks/install-ert/configure-ert.sh
@@ -8,6 +8,12 @@ json_file="json_file/ert.json"
 sudo cp tool-om/om-linux /usr/local/bin
 sudo chmod 755 /usr/local/bin/om-linux
 
+# Check Vars
+echo "================================================================================"
+echo "Google Cloud SQL Host: ${gcloud_sql_instance_ip}"
+echo "================================================================================"
+
+
 # Set Vars
 
 

--- a/tasks/install-ert/configure-ert.sh
+++ b/tasks/install-ert/configure-ert.sh
@@ -32,6 +32,35 @@ perl -pi -e "s/{{pcf_az_2}}/${pcf_az_2}/g" ${json_file}
 perl -pi -e "s/{{pcf_az_3}}/${pcf_az_3}/g" ${json_file}
 perl -pi -e "s/{{terraform_prefix}}/${terraform_prefix}/g" ${json_file}
 
+echo "================================================================================"
+echo "Generating Self Signed Certs for signing SAML authn requests: ${pcf_ert_domain}"
+echo "================================================================================"
+
+# Using the approach in VSphere pipelines
+SYSTEM_DOMAIN=sys.${pcf_ert_domain}
+
+DOMAINS=$(cat <<-EOF
+  {"domains": ["*.${SYSTEM_DOMAIN}", "*.login.${SYSTEM_DOMAIN}", "*.uaa.${SYSTEM_DOMAIN}"] }
+EOF
+)
+
+CMD=./tool-om/om-linux
+chmod +x tool-om/om-linux
+
+OPS_MGR_HOST="https://opsman.$pcf_ert_domain"
+
+SAML_AUTHN_CERT_RAW_RESPONSE=`$CMD -t $OPS_MGR_HOST -u $pcf_opsman_admin -p $pcf_opsman_admin_passwd -k curl -p "/api/v0/rsa_certificates" -x POST -d "$DOMAINS"`
+
+saml_authn_cert=$(echo $SAML_AUTHN_CERT_RAW_RESPONSE | jq '.certificate' | tr -d '"')
+saml_authn_key=$(echo $SAML_AUTHN_CERT_RAW_RESPONSE | jq '.key' | tr -d '"')
+
+# Escape new lines once more
+saml_authn_cert_nonl=$(echo ${saml_authn_cert} | sed 's/\\n/\\\\n/g')
+saml_authn_key_nonl=$(echo ${saml_authn_key} | sed 's/\\n/\\\\n/g')
+
+perl -pi -e "s|{{saml_authn_cert}}|${saml_authn_cert_nonl}|g" ${json_file}
+
+perl -pi -e "s|{{saml_authn_key}}|${saml_authn_key_nonl}|g" ${json_file}
 
 
 if [[ ! -f ${json_file} ]]; then

--- a/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
+++ b/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
@@ -61,28 +61,28 @@
       ".properties.uaa.internal.password_max_retry": {
         "value": "0"
       },
-      ".properties.uaa.service_provider_key_password": {
+      ".uaa.service_provider_key_password": {
         "value": ""
       },
-      ".properties.uaa.apps_manager_access_token_lifetime": {
+      ".uaa.apps_manager_access_token_lifetime": {
         "value": "1209600"
       },
-      ".properties.uaa.apps_manager_refresh_token_lifetime": {
+      ".uaa.apps_manager_refresh_token_lifetime": {
         "value": "1209600"
       },
-      ".properties.uaa.cf_cli_access_token_lifetime": {
+      ".uaa.cf_cli_access_token_lifetime": {
         "value": "7200"
       },
-      ".properties.uaa.cf_cli_refresh_token_lifetime": {
+      ".uaa.cf_cli_refresh_token_lifetime": {
         "value": "1209600"
       },
-      ".properties.uaa.customize_username_label": {
+      ".uaa.customize_username_label": {
         "value": "Email"
       },
-      ".properties.uaa.customize_password_label": {
+      ".uaa.customize_password_label": {
         "value": "Password"
       },
-      ".properties.uaa.proxy_ips_regex": {
+      ".uaa.proxy_ips_regex": {
         "value": "10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|192\\.168\\.\\d{1,3}\\.\\d{1,3}|169\\.254\\.\\d{1,3}\\.\\d{1,3}|127\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|172\\.1[6-9]{1}\\.\\d{1,3}\\.\\d{1,3}|172\\.2[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|172\\.3[0-1]{1}\\.\\d{1,3}\\.\\d{1,3}"
       },
       ".properties.mysql_backups": {
@@ -197,7 +197,7 @@
       ".mysql_monitor.recipient_email": {
         "value" : "c0-coreteam@pivotal.io"
       },
-      ".properties.uaa.service_provider_key_credentials": {
+      ".uaa.service_provider_key_credentials": {
         "value": {
           "cert_pem": "{{saml_authn_cert}}",
           "private_key_pem": "{{saml_authn_key}}"

--- a/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
+++ b/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
@@ -40,7 +40,7 @@
       ".properties.security_acknowledgement": {
         "value": "X"
       },
-      ".properties.uaa": {
+      ".uaa": {
         "value": "internal"
       },
       ".properties.uaa.internal.password_min_length": {

--- a/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
+++ b/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
@@ -61,6 +61,12 @@
       ".properties.uaa.internal.password_max_retry": {
         "value": "0"
       },
+      ".properties.uaa.service_provider_key_credentials.cert_pem": {
+        "value": "{{pcf_ert_ssl_cert}}"
+      },
+      ".properties.uaa.service_provider_key_credentials.private_key_pem": {
+        "value": "{{pcf_ert_ssl_key}}"
+      },
       ".properties.uaa.service_provider_key_password": {
         "value": ""
       },

--- a/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
+++ b/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
@@ -41,7 +41,9 @@
         "value": "X"
       },
       ".property.uaa": {
-        "selector_option": "internal"
+        "value": {
+          "selector_option": "internal"
+        }
       },
       ".properties.uaa.internal.password_min_length": {
         "value": "0"

--- a/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
+++ b/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
@@ -197,7 +197,7 @@
       ".mysql_monitor.recipient_email": {
         "value" : "c0-coreteam@pivotal.io"
       },
-      ".uaa.service_provider_key_credentials": {
+      ".properties.uaa.service_provider_key_credentials": {
         "value": {
           "cert_pem": "{{saml_authn_cert}}",
           "private_key_pem": "{{saml_authn_key}}"

--- a/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
+++ b/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
@@ -40,10 +40,8 @@
       ".properties.security_acknowledgement": {
         "value": "X"
       },
-      ".property.uaa": {
-        "value": {
-          "selector_option": "internal"
-        }
+      ".properties.uaa": {
+        "selector_option": "internal"
       },
       ".properties.uaa.internal.password_min_length": {
         "value": "0"

--- a/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
+++ b/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
@@ -61,6 +61,9 @@
       ".properties.uaa.internal.password_max_retry": {
         "value": "0"
       },
+      ".properties.uaa.service_provider_key_password": {
+        "value": ""
+      },
       ".properties.uaa.apps_manager_access_token_lifetime": {
         "value": "1209600"
       },

--- a/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
+++ b/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
@@ -41,9 +41,7 @@
         "value": "X"
       },
       ".properties.uaa": {
-        "value": {
-          "selector_option": "internal"
-        }
+        "value": "internal"
       },
       ".properties.uaa.internal.password_min_length": {
         "value": "0"

--- a/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
+++ b/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
@@ -41,7 +41,9 @@
         "value": "X"
       },
       ".properties.uaa": {
-        "selector_option": "internal"
+        "value": {
+          "selector_option": "internal"
+        }
       },
       ".properties.uaa.internal.password_min_length": {
         "value": "0"

--- a/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
+++ b/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
@@ -61,12 +61,6 @@
       ".properties.uaa.internal.password_max_retry": {
         "value": "0"
       },
-      ".properties.uaa.service_provider_key_credentials.cert_pem": {
-        "value": "{{pcf_ert_ssl_cert}}"
-      },
-      ".properties.uaa.service_provider_key_credentials.private_key_pem": {
-        "value": "{{pcf_ert_ssl_key}}"
-      },
       ".properties.uaa.service_provider_key_password": {
         "value": ""
       },
@@ -202,6 +196,12 @@
       },
       ".mysql_monitor.recipient_email": {
         "value" : "c0-coreteam@pivotal.io"
+      },
+      ".uaa.service_provider_key_credentials": {
+        "value": {
+          "cert_pem": "{{saml_authn_cert}}",
+          "private_key_pem": "{{saml_authn_key}}"
+        }
       }
     }
   },

--- a/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
+++ b/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
@@ -61,12 +61,6 @@
       ".properties.uaa.internal.password_max_retry": {
         "value": "0"
       },
-      ".properties.uaa.service_provider_key_credentials.cert_pem": {
-        "value": ""
-      },
-      ".properties.uaa.service_provider_key_credentials.private_key_pem": {
-        "value": ""
-      },
       ".properties.uaa.apps_manager_access_token_lifetime": {
         "value": "1209600"
       },

--- a/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
+++ b/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
@@ -40,6 +40,54 @@
       ".properties.security_acknowledgement": {
         "value": "X"
       },
+      ".properties.uaa": {
+        "value": "internal"
+      },
+      ".properties.uaa.internal.password_min_length": {
+        "value": "0"
+      },
+      ".properties.uaa.internal.password_min_uppercase": {
+        "value": "0"
+      },
+      ".properties.uaa.internal.password_min_lowercase": {
+        "value": "0"
+      },
+      ".properties.uaa.internal.password_min_numeric": {
+        "value": "0"
+      },
+      ".properties.uaa.internal.password_min_special": {
+        "value": "0"
+      },
+      ".properties.uaa.internal.password_max_retry": {
+        "value": "0"
+      },
+      ".properties.uaa.service_provider_key_credentials.cert_pem": {
+        "value": ""
+      },
+      ".properties.uaa.service_provider_key_credentials.private_key_pem": {
+        "value": ""
+      },
+      ".properties.uaa.apps_manager_access_token_lifetime": {
+        "value": "1209600"
+      },
+      ".properties.uaa.apps_manager_refresh_token_lifetime": {
+        "value": "1209600"
+      },
+      ".properties.uaa.cf_cli_access_token_lifetime": {
+        "value": "7200"
+      },
+      ".properties.uaa.cf_cli_refresh_token_lifetime": {
+        "value": "1209600"
+      },
+      ".properties.uaa.customize_username_label": {
+        "value": "Email"
+      },
+      ".properties.uaa.customize_password_label": {
+        "value": "Password"
+      },
+      ".properties.uaa.proxy_ips_regex": {
+        "value": "10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|192\\.168\\.\\d{1,3}\\.\\d{1,3}|169\\.254\\.\\d{1,3}\\.\\d{1,3}|127\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|172\\.1[6-9]{1}\\.\\d{1,3}\\.\\d{1,3}|172\\.2[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|172\\.3[0-1]{1}\\.\\d{1,3}\\.\\d{1,3}"
+      },
       ".properties.mysql_backups": {
         "value": "disable"
       },

--- a/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
+++ b/tasks/install-ert/json_templates/gcp/c0-gcp-base/ert-template.json
@@ -40,8 +40,8 @@
       ".properties.security_acknowledgement": {
         "value": "X"
       },
-      ".uaa": {
-        "value": "internal"
+      ".property.uaa": {
+        "selector_option": "internal"
       },
       ".properties.uaa.internal.password_min_length": {
         "value": "0"

--- a/tasks/install-ert/scripts/iaas-specific-config/gcp/run.sh
+++ b/tasks/install-ert/scripts/iaas-specific-config/gcp/run.sh
@@ -21,6 +21,8 @@ gcloud_sql_instance_cmd="gcloud sql instances list --format json | jq '.[] | sel
 gcloud_sql_instance=$(eval ${gcloud_sql_instance_cmd})
 gcloud_sql_instance_ip=$(gcloud sql instances list | grep ${gcloud_sql_instance} | awk '{print$4}')
 
+echo "found GCP Cloud SQL host: ${gcloud_sql_instance_ip}"
+
 declare -a arr=(
 "db_app_usage_service_username"
 "db_app_usage_service_password"
@@ -36,6 +38,7 @@ declare -a arr=(
 "db_uaa_password"
 "db_ccdb_username"
 "db_ccdb_password"
+"gcloud_sql_instance_ip"
 )
 
 echo "finding variables to replace in your json config file using the value from the env variable of the same name"


### PR DESCRIPTION
added the .uaa.* properties corresponding to the "Authentication and Enterprise SSO" tab in ERT configuration; also added the gcloud_sql_instance_ip property for inclusion into the iterator that replaces params in the config
NOTE: the configure-ert.sh file might cause merge conflicts with existing modifications in other branches