### PR TITLE
Generate cert uri via parameter - different opsmgr endpoints for 1.9 and 1.10 ops manager

### DIFF
--- a/tasks/install-ert/configure-json/task.sh
+++ b/tasks/install-ert/configure-json/task.sh
@@ -32,7 +32,7 @@ domains=$(cat <<-EOF
   {"domains": ["*.${system_domain}", "*.login.${system_domain}", "*.uaa.${system_domain}"] }
 EOF
 )
-saml_cert_response=`$OM_CMD -t $ops_mgr_host -u $pcf_opsman_admin -p $pcf_opsman_admin_passwd -k curl -p "/api/v0/rsa_certificates" -x POST -d "$domains"`
+saml_cert_response=`$OM_CMD -t $ops_mgr_host -u $pcf_opsman_admin -p $pcf_opsman_admin_passwd -k curl -p "/api/v0/certificates/generate" -x POST -d "$domains"`
 saml_cert_pem=$(echo $saml_cert_response | jq --raw-output '.certificate')
 saml_key_pem=$(echo $saml_cert_response | jq --raw-output '.key')
 


### PR DESCRIPTION
To account for the difference in certificate generating endpoint in opsmanager between 1.9 and 1.10 - 

```
- /api/v0/certificates/generate (for 1.10)
- /api/v0/rsa_certificates (for 1.9)
```