### PR TITLE
Fixes issue with terraform destroy of RDS on AWS

### DIFF
--- a/tasks/install-pcf-aws/terraform/rds.tf
+++ b/tasks/install-pcf-aws/terraform/rds.tf
@@ -21,4 +21,5 @@ resource "aws_db_instance" "pcf_rds" {
     multi_az                = true
     backup_retention_period = 7
     apply_immediately       = true
+    skip_final_snapshot     = true
 }


### PR DESCRIPTION
[#145883965] 

terraform now sets the flag to create snapshots on deletion to true and throws an exception if the snapshot identifier is not provided. This PR provides the final snapshot identifier.

