### PR TITLE
Adjustments to normalize https usage of opsman and limiting AZ usage

### DIFF
--- a/tasks/config-opsdir/task.sh
+++ b/tasks/config-opsdir/task.sh
@@ -22,6 +22,7 @@ IAAS_CONFIGURATION=$(cat <<-EOF
 EOF
 )
 
+if [ ! -z $AZ_3 ];then
 AZ_CONFIGURATION=$(cat <<-EOF
 {
   "availability_zones": [
@@ -44,6 +45,38 @@ AZ_CONFIGURATION=$(cat <<-EOF
 }
 EOF
 )
+elif [ ! -z $AZ_2 ];then
+AZ_CONFIGURATION=$(cat <<-EOF
+{
+  "availability_zones": [
+    {
+      "name": "$AZ_1",
+      "cluster": "$AZ_1_CLUSTER_NAME",
+      "resource_pool": "$AZ_1_RP_NAME"
+    },
+    {
+      "name": "$AZ_2",
+      "cluster": "$AZ_2_CLUSTER_NAME",
+      "resource_pool": "$AZ_2_RP_NAME"
+    }
+  ]
+}
+EOF
+)
+else
+AZ_CONFIGURATION=$(cat <<-EOF
+{
+  "availability_zones": [
+    {
+      "name": "$AZ_1",
+      "cluster": "$AZ_1_CLUSTER_NAME",
+      "resource_pool": "$AZ_1_RP_NAME"
+    }
+  ]
+}
+EOF
+)
+fi
 
 INFRA_AZS=$(fn_get_azs "$INFRA_NW_AZS")
 DEPLOYMENT_AZS=$(fn_get_azs "$DEPLOYMENT_NW_AZS")

--- a/tasks/deploy-opsman-vm/task.sh
+++ b/tasks/deploy-opsman-vm/task.sh
@@ -84,7 +84,9 @@ EOF
         echo "...VM is running! $OUTPUT"
         timeout=$((SECONDS+${OPSMAN_TIMEOUT}))
         while [[ $started ]]; do
-          HTTP_OUTPUT=$(curl --write-out %{http_code} --silent --output /dev/null ${OPSMAN_URI} -k)
+          export http_proxy=''
+          export https_proxy=''
+          HTTP_OUTPUT=$(curl -k --write-out %{http_code} --silent --output /dev/null https://${OPSMAN_IP})
           if [[ $HTTP_OUTPUT == *"302"* || $HTTP_OUTPUT == *"301"* ]]; then
             echo "Site is started! $OUTPUT >>> $HTTP_OUTPUT"
             exit 0


### PR DESCRIPTION
In tasks/deploy-opsman-vm/task.sh, when a proxy is used (http_proxy and https_proxy), attempts to talk to the opsman IP address will try to use the proxy. It should bypass the proxy since the value here is an ip address.

Also, use https for the call to opsman as is done in nearly all other tasks.

For tasks/config-opsdir/task.sh, only pass AZ's that are defined in the params.yml file - allowing those with one or two AZs to use this pipeline.