### PR TITLE
Update ERT resource in install-pcf/vsphere pipeline

### DIFF
--- a/install-pcf/vsphere/pipeline.yml
+++ b/install-pcf/vsphere/pipeline.yml
@@ -28,9 +28,12 @@ resources:
 
 - name: elastic-runtime
   type: pivnet
+  check_every: 4h
   source:
     api_token: {{pivnet_token}}
     product_slug: elastic-runtime
+    product_version: 1\.10\.*
+    sort_by: semver
 
 jobs:
 - name: install-opsmgr


### PR DESCRIPTION
[#145790281]

There are no issues with the additional fields in ERT tile 1.10.9 and the VSphere pipelines as the Vsphere pipelines use an internal Mysql database vs using an external database like for AWS/GCP (and hence the need to provision them explicitly). However the ERT tile version is not pinned today, so the pipeline ends up downloading the latest of current major version which may not be always appropriate. This PR pins it to 1.10.x along the lines of what is done for AWS/GCP pipelines.