### PR TITLE
Make task URI compatible like other tasks

### DIFF
--- a/tasks/config-ert/task.sh
+++ b/tasks/config-ert/task.sh
@@ -2,12 +2,12 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-CF_RELEASE=`om-linux -t https://$OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k available-products | grep cf`
+CF_RELEASE=`om-linux -t $OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k available-products | grep cf`
 
 PRODUCT_NAME=`echo $CF_RELEASE | cut -d"|" -f2 | tr -d " "`
 PRODUCT_VERSION=`echo $CF_RELEASE | cut -d"|" -f3 | tr -d " "`
 
-om-linux -t https://$OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k stage-product -p $PRODUCT_NAME -v $PRODUCT_VERSION
+om-linux -t $OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k stage-product -p $PRODUCT_NAME -v $PRODUCT_VERSION
 
 ERT_AZS=$(echo $DEPLOYMENT_NW_AZS | jq --raw-input 'split(",") | map({name: .})')
 
@@ -30,7 +30,7 @@ DOMAINS=$(cat <<-EOF
 EOF
 )
 
-  CERTIFICATES=`om-linux -t https://$OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k curl -p "$OPS_MGR_GENERATE_SSL_ENDPOINT" -x POST -d "$DOMAINS"`
+  CERTIFICATES=`om-linux -t $OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k curl -p "$OPS_MGR_GENERATE_SSL_ENDPOINT" -x POST -d "$DOMAINS"`
 
   export SSL_CERT=`echo $CERTIFICATES | jq '.certificate'`
   export SSL_PRIVATE_KEY=`echo $CERTIFICATES | jq '.key'`
@@ -135,7 +135,7 @@ CF_RESOURCES=$(cat <<-EOF
 EOF
 )
 
-om-linux -t https://$OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k configure-product -n cf -p "$CF_PROPERTIES" -pn "$CF_NETWORK" -pr "$CF_RESOURCES"
+om-linux -t $OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k configure-product -n cf -p "$CF_PROPERTIES" -pn "$CF_NETWORK" -pr "$CF_RESOURCES"
 
 if [[ "$AUTHENTICATION_MODE" == "internal" ]]; then
 echo "Configuring Internal Authentication in ERT..."
@@ -208,7 +208,7 @@ saml_cert_domains=$(cat <<-EOF
 EOF
 )
 
-saml_cert_response=`om-linux -t https://$OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k curl -p "$OPS_MGR_GENERATE_SSL_ENDPOINT" -x POST -d "$saml_cert_domains"`
+saml_cert_response=`om-linux -t $OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k curl -p "$OPS_MGR_GENERATE_SSL_ENDPOINT" -x POST -d "$saml_cert_domains"`
 
 saml_cert_pem=$(echo $saml_cert_response | jq --raw-output '.certificate')
 saml_key_pem=$(echo $saml_cert_response | jq --raw-output '.key')
@@ -227,7 +227,7 @@ CF_AUTH_WITH_SAML_CERTS=$(echo $CF_AUTH_PROPERTIES | jq \
   --raw-output)
 
 
-om-linux -t https://$OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k configure-product -n cf -p "$CF_AUTH_WITH_SAML_CERTS"
+om-linux -t $OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k configure-product -n cf -p "$CF_AUTH_WITH_SAML_CERTS"
 
 if [[ ! -z "$SYSLOG_HOST" ]]; then
 
@@ -254,7 +254,7 @@ CF_SYSLOG_PROPERTIES=$(cat <<-EOF
 EOF
 )
 
-om-linux -t https://$OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k configure-product -n cf -p "$CF_SYSLOG_PROPERTIES"
+om-linux -t $OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k configure-product -n cf -p "$CF_SYSLOG_PROPERTIES"
 
 fi
 
@@ -289,7 +289,7 @@ CF_SMTP_PROPERTIES=$(cat <<-EOF
 EOF
 )
 
-om-linux -t https://$OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k configure-product -n cf -p "$CF_SMTP_PROPERTIES"
+om-linux -t $OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k configure-product -n cf -p "$CF_SMTP_PROPERTIES"
 
 fi
 
@@ -342,4 +342,4 @@ EOF
 
 fi
 
-om-linux -t https://$OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k configure-product -n cf -p "$CF_SSL_TERM_PROPERTIES"
+om-linux -t $OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k configure-product -n cf -p "$CF_SSL_TERM_PROPERTIES"

--- a/tasks/config-opsdir/task.sh
+++ b/tasks/config-opsdir/task.sh
@@ -155,7 +155,7 @@ EOF
 
 echo "Configuring IaaS and Director..."
 om-linux \
-  --target https://$OPS_MGR_HOST \
+  --target $OPS_MGR_HOST \
   --skip-ssl-validation \
   --username $OPS_MGR_USR \
   --password $OPS_MGR_PWD \
@@ -164,21 +164,21 @@ om-linux \
   --director-configuration "$DIRECTOR_CONFIG"
 
 echo "Configuring availability zones..."
-om-linux -t https://$OPS_MGR_HOST -k -u $OPS_MGR_USR -p $OPS_MGR_PWD \
+om-linux -t $OPS_MGR_HOST -k -u $OPS_MGR_USR -p $OPS_MGR_PWD \
   curl -p "/api/v0/staged/director/availability_zones" \
   -x PUT -d "$AZ_CONFIGURATION"
 
 echo "Configuring networks..."
-om-linux -t https://$OPS_MGR_HOST -k -u $OPS_MGR_USR -p $OPS_MGR_PWD \
+om-linux -t $OPS_MGR_HOST -k -u $OPS_MGR_USR -p $OPS_MGR_PWD \
   curl -p "/api/v0/staged/director/networks" \
   -x PUT -d "$NETWORK_CONFIGURATION"
 
 echo "Configuring network assignment..."
-om-linux -t https://$OPS_MGR_HOST -k -u $OPS_MGR_USR -p $OPS_MGR_PWD \
+om-linux -t $OPS_MGR_HOST -k -u $OPS_MGR_USR -p $OPS_MGR_PWD \
   curl -p "/api/v0/staged/director/network_and_az" \
   -x PUT -d "$NETWORK_ASSIGNMENT"
 
 echo "Configuring security..."
-om-linux -t https://$OPS_MGR_HOST -k -u $OPS_MGR_USR -p $OPS_MGR_PWD \
+om-linux -t $OPS_MGR_HOST -k -u $OPS_MGR_USR -p $OPS_MGR_PWD \
   curl -p "/api/v0/staged/director/properties" \
   -x PUT -d "$SECURITY_CONFIG"

--- a/tasks/config-opsman/task.sh
+++ b/tasks/config-opsman/task.sh
@@ -1,12 +1,12 @@
 #!/bin/bash -e
 
-until $(curl --output /dev/null -k --silent --head --fail https://$OPS_MGR_HOST/setup); do
+until $(curl --output /dev/null -k --silent --head --fail $OPS_MGR_HOST/setup); do
     printf '.'
     sleep 5
 done
 
 om-linux \
-  --target https://$OPS_MGR_HOST \
+  --target $OPS_MGR_HOST \
   --skip-ssl-validation \
   configure-authentication \
   --username $OPS_MGR_USR \

--- a/tasks/disable-ert-errands/task.sh
+++ b/tasks/disable-ert-errands/task.sh
@@ -13,6 +13,6 @@ ERT_ERRANDS=$(cat <<-EOF
 EOF
 )
 
-CF_GUID=`om-linux -t https://$OPS_MGR_HOST -k -u $OPS_MGR_USR -p $OPS_MGR_PWD curl -p "/api/v0/deployed/products" -x GET | jq --raw-output '.[] | select(.installation_name | contains("cf-")) | .guid'`
+CF_GUID=`om-linux -t $OPS_MGR_HOST -k -u $OPS_MGR_USR -p $OPS_MGR_PWD curl -p "/api/v0/deployed/products" -x GET | jq --raw-output '.[] | select(.installation_name | contains("cf-")) | .guid'`
 
-om-linux -t https://$OPS_MGR_HOST -k -u $OPS_MGR_USR -p $OPS_MGR_PWD curl -p "/api/v0/staged/products/$CF_GUID/errands" -x PUT -d "$ERT_ERRANDS"
+om-linux -t $OPS_MGR_HOST -k -u $OPS_MGR_USR -p $OPS_MGR_PWD curl -p "/api/v0/staged/products/$CF_GUID/errands" -x PUT -d "$ERT_ERRANDS"

--- a/tasks/install-pcf-gcp/functions/config-director-json-fn-opsman-auth.sh
+++ b/tasks/install-pcf-gcp/functions/config-director-json-fn-opsman-auth.sh
@@ -22,7 +22,7 @@ function fn_opsman_auth {
   xuaacsrf=$(cat mycookiejar | grep X-Uaa-Csrf | awk '{print$7}')
   rqst_form_data="-d 'username=${pcf_opsman_admin}&password=${pcf_opsman_admin_passwd}&X-Uaa-Csrf=${xuaacsrf}'"
   chk_login=$(fn_opsman_curl "POST" "uaa/login.do" "${xuaacsrf}" "--NOENCODE" "${rqst_form_data}" | grep "Location:" | awk '{print$2}' | awk -F '&' '{print$4}')
-  url_authorize_state=$(echo "https://${opsman_host}/${url_authorize}" | awk -F '&' '{print$4}')
+  url_authorize_state=$(echo "${opsman_host}/${url_authorize}" | awk -F '&' '{print$4}')
 
   # Validate
   if [[ ! ${chk_login} == ${url_authorize_state} || -z ${chk_login} ]]; then

--- a/tasks/install-pcf-gcp/functions/config-director-json-fn-opsman-curl.sh
+++ b/tasks/install-pcf-gcp/functions/config-director-json-fn-opsman-curl.sh
@@ -35,7 +35,7 @@ function fn_opsman_curl() {
 
   ####### Host URL Builder #######
 
-  curl_host="https://${opsman_host}/${2}"
+  curl_host="${opsman_host}/${2}"
 
   ####### Post Form Data Builder #######
 

--- a/tasks/install-pcf-gcp/functions/config-director-json-fn-opsman-extensions.sh
+++ b/tasks/install-pcf-gcp/functions/config-director-json-fn-opsman-extensions.sh
@@ -73,12 +73,12 @@ function fn_form_gen_ert_az_and_network_assignments {
   local json=${@}
 
   # Get ERT Product ID To set URL
-  uaac target https://${opsman_host}/uaa --skip-ssl-validation > /dev/null 2>&1
+  uaac target ${opsman_host}/uaa --skip-ssl-validation > /dev/null 2>&1
   uaac token owner get opsman admin -s "" -p ${pcf_opsman_admin_passwd} > /dev/null 2>&1
   export opsman_bearer_token=$(uaac context | grep access_token | awk -F ":" '{print$2}' | tr -d ' ')
 
   ert_product_id=$(curl -s -k -X GET -H "Content-Type: application/json" -H "Authorization: Bearer $opsman_bearer_token" \
-    "https://${opsman_host}/api/v0/staged/products" | \
+    "${opsman_host}/api/v0/staged/products" | \
     jq '.[] | select(.type == "cf") | .guid'  | tr -d '"')
 
   # Auth to OpsMan

--- a/tasks/upload-product-and-stemcell/task.sh
+++ b/tasks/upload-product-and-stemcell/task.sh
@@ -14,9 +14,9 @@ pivnet-cli download-product-files -p stemcells -r $STEMCELL_VERSION -g "*vsphere
 
 SC_FILE_PATH=`find ./ -name *.tgz`
 
-om-linux -t https://$OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k upload-product -p $FILE_PATH
+om-linux -t $OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k upload-product -p $FILE_PATH
 
-om-linux -t https://$OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k upload-stemcell -s $SC_FILE_PATH
+om-linux -t $OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k upload-stemcell -s $SC_FILE_PATH
 
 if [ ! -f "$SC_FILE_PATH" ]; then
     echo "Stemcell file not found!"


### PR DESCRIPTION
Other tasks in the various pipelines do not hard-code a protocol when using the opsman_uri param. It is necessary for this param to be https://someurl.somedomain.com when you are in a firewalled environment where access on port 80 is not permitted.