### PR TITLE
Use https with curl and om-tool

### DIFF
--- a/tasks/apply-changes/task.sh
+++ b/tasks/apply-changes/task.sh
@@ -17,7 +17,7 @@
 echo "Applying changes on Ops Manager @ ${OPSMAN_URI}"
 
 om-linux \
-  --target "${OPSMAN_URI}" \
+  --target "https://${OPSMAN_URI}" \
   --skip-ssl-validation \
   --username "${OPSMAN_USERNAME}" \
   --password "${OPSMAN_PASSWORD}" \

--- a/tasks/deploy-opsman-vm/task.sh
+++ b/tasks/deploy-opsman-vm/task.sh
@@ -84,7 +84,7 @@ EOF
         echo "...VM is running! $OUTPUT"
         timeout=$((SECONDS+${OPSMAN_TIMEOUT}))
         while [[ $started ]]; do
-          HTTP_OUTPUT=$(curl --write-out %{http_code} --silent --output /dev/null ${OPSMAN_URI} -k)
+          HTTP_OUTPUT=$(curl --write-out %{http_code} --silent --output /dev/null https://${OPSMAN_URI} -k)
           if [[ $HTTP_OUTPUT == *"302"* || $HTTP_OUTPUT == *"301"* ]]; then
             echo "Site is started! $OUTPUT >>> $HTTP_OUTPUT"
             exit 0

--- a/tasks/export-opsmgr-diagnostic-report/task.sh
+++ b/tasks/export-opsmgr-diagnostic-report/task.sh
@@ -19,7 +19,7 @@ function main() {
   local cwd
   cwd="${1}"
 
-   om-linux --target "${OPSMAN_URI}" \
+   om-linux --target "https://${OPSMAN_URI}" \
      --skip-ssl-validation \
      --username "${OPSMAN_USERNAME}" \
      --password "${OPSMAN_PASSWORD}" \

--- a/tasks/export-opsmgr-settings/task.sh
+++ b/tasks/export-opsmgr-settings/task.sh
@@ -19,7 +19,7 @@ function main() {
   local cwd
   cwd="${1}"
 
-  om-linux --target "${OPSMAN_URI}" \
+  om-linux --target "https://${OPSMAN_URI}" \
      --skip-ssl-validation \
      --username "${OPSMAN_USERNAME}" \
      --password "${OPSMAN_PASSWORD}" \

--- a/tasks/import-opsmgr-settings/task.sh
+++ b/tasks/import-opsmgr-settings/task.sh
@@ -25,7 +25,7 @@ function main() {
   done
   printf '\n'
 
-  om-linux --target "${OPSMAN_URI}" \
+  om-linux --target "https://${OPSMAN_URI}" \
       --skip-ssl-validation \
       import-installation \
       --installation "${cwd}/opsmgr-settings/${OPSMAN_SETTINGS_FILENAME}" \

--- a/tasks/import-opsmgr-settings/task.sh
+++ b/tasks/import-opsmgr-settings/task.sh
@@ -19,7 +19,7 @@ function main() {
   cwd="${1}"
 
   printf "Waiting for %s to come up" "$OPSMAN_URI"
-  until $(curl --output /dev/null --silent --head --fail -k ${OPSMAN_URI}); do
+  until $(curl --output /dev/null --silent --head --fail -k https://${OPSMAN_URI}); do
     printf '.'
     sleep 5
   done

--- a/tasks/restore-stemcells/task.sh
+++ b/tasks/restore-stemcells/task.sh
@@ -25,7 +25,7 @@ function main() {
 
   for stemcell in ${cwd}/stemcells/*.tgz; do
     printf "Uploading %s to %s ...\n" "${stemcell}" "${OPSMAN_URI}"
-    om-linux --target "${OPSMAN_URI}" \
+    om-linux --target "https://${OPSMAN_URI}" \
         --skip-ssl-validation \
         --username "${OPSMAN_USERNAME}" \
         --password "${OPSMAN_PASSWORD}" \

--- a/tasks/stage-product/task.sh
+++ b/tasks/stage-product/task.sh
@@ -24,7 +24,7 @@ function main() {
     version="$(unzip -p *.pivotal 'metadata/*.yml' | grep 'product_version:' | cut -d ':' -f 2 | tr -d ' ' | tr -d "'")"
   popd
 
-  om-linux --target "${OPSMAN_URI}" \
+  om-linux --target "https://${OPSMAN_URI}" \
      --skip-ssl-validation \
      --username "${OPSMAN_USERNAME}" \
      --password "${OPSMAN_PASSWORD}" \

--- a/tasks/upload-product/task.sh
+++ b/tasks/upload-product/task.sh
@@ -25,7 +25,7 @@ function main() {
     export TILE_UPLOAD_TIMEOUT=1800 
   fi
 
-  om-linux --target "${OPSMAN_URI}" \
+  om-linux --target "https://${OPSMAN_URI}" \
      --skip-ssl-validation \
      --username "${OPSMAN_USERNAME}" \
      --password "${OPSMAN_PASSWORD}" \

--- a/tasks/upload-stemcell/task.sh
+++ b/tasks/upload-stemcell/task.sh
@@ -30,7 +30,7 @@ stemcell-downloader \
 
 stemcell="$(ls -1 "${root}"/stemcell/*.tgz)"
 
-om-linux --target ${OPSMAN_URI} \
+om-linux --target "https://${OPSMAN_URI}" \
   --skip-ssl-validation \
   --username "${OPSMAN_USERNAME}" \
   --password "${OPSMAN_PASSWORD}" \

--- a/tasks/wait-opsman-clear/task.sh
+++ b/tasks/wait-opsman-clear/task.sh
@@ -26,7 +26,7 @@ function main() {
   while :
   do
 
-      om-linux --target "${OPSMAN_URI}" \
+      om-linux --target "https://${OPSMAN_URI}" \
            --skip-ssl-validation \
            --username "${OPSMAN_USERNAME}" \
            --password "${OPSMAN_PASSWORD}" \
@@ -38,7 +38,7 @@ function main() {
         exit 1
       fi
 
-      om-linux --target "${OPSMAN_URI}" \
+      om-linux --target "https://${OPSMAN_URI}" \
            --skip-ssl-validation \
            --username "${OPSMAN_USERNAME}" \
            --password "${OPSMAN_PASSWORD}" \


### PR DESCRIPTION
Params.yml says of opsman_uri:
````
FQDN to access Ops Manager without protocol (will use https), ex: opsmgr.example.com
````

Without prepending https to the curl and om-tool commands, this will not work as advertised