### PR TITLE
Fix upgrade-ert regex for pivnet

### DIFF
--- a/upgrade-ert/params.yml
+++ b/upgrade-ert/params.yml
@@ -19,7 +19,7 @@ pivnet_token: CHANGEME
 opsman_admin_username: CHANGEME
 opsman_admin_password: CHANGEME
 
-ert_major_minor_version: 1\.10\.*  # ERT minor version to track
+ert_major_minor_version: ^1\.10\..*$  # ERT minor version to track
 # Ops Manager Url
 # eg. https://myopsman.mydomain.com
 opsman_uri: CHANGEME


### PR DESCRIPTION
The previous regex will match 1.10 ended by zero or more dots.
For example a version 2.1.10 would match or a version like
1.101.4 or even a version like 1.1.10. This commit makes the
regex much more specific to avoid future issues.