### PR TITLE
Fixed an `unbound variable` error in disable-errands

### DIFF
--- a/tasks/disable-errands/task.sh
+++ b/tasks/disable-errands/task.sh
@@ -18,6 +18,8 @@ if [[ -z "$enabled_errands" ]]; then
   exit 0
 fi
 
+errands_to_disable=''
+
 if [[ "$ERRANDS_TO_DISABLE" == "all" ]]; then
   errands_to_disable="${enabled_errands[@]}"
 elif [[ "$ERRANDS_TO_DISABLE" != "" ]] && [[ "$ERRANDS_TO_DISABLE" != "none" ]]; then


### PR DESCRIPTION
Deploying install-pcf/vsphere received the following error in `deploy-ert`:

```
>_ disable-errands
pcf-pipelines/tasks/disable-errands/task.sh: line 27: errands_to_disable: unbound variable
```

This fix simply declares the local variable errands_to_disable to avoid the `unbound variable` error.