### PR TITLE
Fixes regex for version regex output for params

### DIFF
--- a/functions/allow_only_patch_upgrades.sh
+++ b/functions/allow_only_patch_upgrades.sh
@@ -44,7 +44,7 @@ function allow_only_patch_upgrades {
     your prior knowledge."
     echo
     echo "To upgrade patch releases, we suggest using the following version regex in your params file:"
-    echo "$deployed_version" | awk -F"." '{print "^"$1"\\\."$2"\\..*$"}'
+    echo "$deployed_version" | awk -F"." '{print "^"$1"\\."$2"\\..*$"}'
     exit 1
   fi
 }


### PR DESCRIPTION
There's an extra back slash in the regex.