### PR TITLE
Prevent grep from returning multiple products

### DIFF
--- a/functions/allow_only_patch_upgrades.sh
+++ b/functions/allow_only_patch_upgrades.sh
@@ -25,7 +25,7 @@ function allow_only_patch_upgrades {
       --username "${OPS_MGR_USR}" \
       --password "${OPS_MGR_PWD}" \
       --skip-ssl-validation \
-      deployed-products | grep "${PRODUCT_NAME}" | awk -F"|" '{print $3 }' | awk -F"." '{print $1"."$2}'
+      deployed-products | grep "^| ${PRODUCT_NAME} *|" | awk -F"|" '{print $3 }' | awk -F"." '{print $1"."$2}'
     )
   if [[ `ls ${PRODUCT_DIR} | grep ${deployed_version}` ]]; then
     echo "we have a safe upgrade for version: ${deployed_version}";


### PR DESCRIPTION
Grep was returning multiple product versions if `${PRODUCT_NAME}` existed in multiple products. For example, if `${PRODUCT_NAME}` was set to cf, then versions were returned for cf and apigee-cf-service-broker.

```
$ export PRODUCT_NAME=cf
$ om --target "https://${OPS_MGR_HOST}" --username "${OPS_MGR_USR}" --password "${OPS_MGR_PWD}" --skip-ssl-validation deployed-products | grep ${PRODUCT_NAME} | awk -F"|" '{print $3 }' | awk -F"." '{print $1"."$2}'
 1.11
 2.0
```
In the above example, version 1.11 is for cf and version 2.0 is for apigee-cf-service-broker.

We changed the grep to include a regex so that only the specified product name would match.