### PR TITLE
Fixes printed message for patch upgrades

### DIFF
--- a/functions/allow_only_patch_upgrades.sh
+++ b/functions/allow_only_patch_upgrades.sh
@@ -51,7 +51,7 @@ function allow_only_patch_upgrades {
     your prior knowledge."
     echo
     echo "To upgrade patch releases, we suggest using the following version regex in your params file:"
-    echo "${deployed_version_major_minor}" | awk -F"." '{print "^"$1"\\\."$2"\\..*$"}'
+    echo "${deployed_version_major_minor}" | awk -F"." '{print "^"$1"\\."$2"\\..*$"}'
     exit 1
   fi
 }


### PR DESCRIPTION
The printed message suggesting users to use the "following version regex in your params file" currently has an extra backslash in the regex. Having this extra backslash keeps the Regulator from working properly.