### PR TITLE
Add comment for NTP and DNS in vsphere/opsman-upgrade

### DIFF
--- a/upgrade-ops-manager/vsphere/params.yml
+++ b/upgrade-ops-manager/vsphere/params.yml
@@ -31,7 +31,7 @@ opsman_vm_folder: CHANGEME
 opsman_ip: CHANGEME
 netmask: CHANGEME
 gateway: CHANGEME
-dns: CHANGEME
-ntp: CHANGEME
+dns: CHANGEME #example: 8.8.8.8,8.8.4.4
+ntp: CHANGEME #example: 0.pool.ntp.org,1.pool.ntp.org
 opsman_network: CHANGEME
 git_private_key:


### PR DESCRIPTION
It's not clear what format the NTP and DNS servers
are specified. This comment attempts to clarify that.