### PR TITLE
Custom stemcells

### DIFF
--- a/tasks/download-pivnet-stemcells/task.sh
+++ b/tasks/download-pivnet-stemcells/task.sh
@@ -43,7 +43,6 @@ function main() {
     stemcell_os_regex="bosh-stemcell-[0-9]+\.[0-9]+-vsphere-esxi-([A-z0-9-]*)-go_agent.tgz"
     if [[ $stemcell =~ $stemcell_os_regex ]]; then
       stemcell_os=${BASH_REMATCH[1]}
-      echo "Found stemcell os: $stemcell_os"
     else
       abort "Could not extract stemcell os type."
     fi
@@ -58,6 +57,7 @@ function abort() {
 
 function download_stemcell_version() {
   local stemcell_version
+  local stemcell_os
   stemcell_version="$1"
   stemcell_os="$2"
 

--- a/tasks/download-pivnet-stemcells/task.sh
+++ b/tasks/download-pivnet-stemcells/task.sh
@@ -40,7 +40,12 @@ function main() {
   for stemcell in "${stemcells[@]}"; do
     local stemcell_version
     stemcell_version=$(echo "$stemcell" | grep -Eo "[0-9]+(\.[0-9]+)?")
-    stemcell_os=$(echo "$stemcell" | grep -Eo "bosh-stemcell-[0-9]+\.[0-9]+-vsphere-esxi-([A-z0-9-]*)-go_agent.tgz")
+    stemcell_os_regex="bosh-stemcell-[0-9]+\.[0-9]+-vsphere-esxi-([A-z0-9-]*)-go_agent.tgz"
+    if [[ $stemcell ~= $stemcell_os_regex ]]; then
+      stemcell_os=${BASH_REMATCH[1]}
+    else
+      abort "Could not extract stemcell os type."
+    fi
     download_stemcell_version $stemcell_version $stemcell_os
   done
 }

--- a/tasks/download-pivnet-stemcells/task.sh
+++ b/tasks/download-pivnet-stemcells/task.sh
@@ -81,7 +81,9 @@ function download_stemcell_version() {
 
 function grab_custom_stemcell() {
   stemcell_path="custom-stemcells/bosh-stemcell-${1}-${IAAS_TYPE}-esxi-${2}-go_agent.tgz" 
+  echo Checking for custom stemcell at $stemcell_path
   if [ -e $stemcell_path ]; then
+    echo Found custom stemcell and copying to download directory
     cp $stemcell_path $download_dir
     return 0
   fi

--- a/tasks/download-pivnet-stemcells/task.sh
+++ b/tasks/download-pivnet-stemcells/task.sh
@@ -43,6 +43,7 @@ function main() {
     stemcell_os_regex="bosh-stemcell-[0-9]+\.[0-9]+-vsphere-esxi-([A-z0-9-]*)-go_agent.tgz"
     if [[ $stemcell =~ $stemcell_os_regex ]]; then
       stemcell_os=${BASH_REMATCH[1]}
+      echo "Found stemcell os: $stemcell_os"
     else
       abort "Could not extract stemcell os type."
     fi

--- a/tasks/download-pivnet-stemcells/task.sh
+++ b/tasks/download-pivnet-stemcells/task.sh
@@ -56,7 +56,7 @@ function download_stemcell_version() {
   stemcell_os="$2"
 
   # check to see if we have a custom stemcell that matches first
-  if [[ grab_custom_stemcell $stemcell_version $stemcell_os ]]; then
+  if grab_custom_stemcell $stemcell_version $stemcell_os; then
     return 0
   fi 
 

--- a/tasks/download-pivnet-stemcells/task.sh
+++ b/tasks/download-pivnet-stemcells/task.sh
@@ -41,7 +41,7 @@ function main() {
     local stemcell_version
     stemcell_version=$(echo "$stemcell" | grep -Eo "[0-9]+(\.[0-9]+)?")
     stemcell_os_regex="bosh-stemcell-[0-9]+\.[0-9]+-vsphere-esxi-([A-z0-9-]*)-go_agent.tgz"
-    if [[ $stemcell ~= $stemcell_os_regex ]]; then
+    if [[ $stemcell =~ $stemcell_os_regex ]]; then
       stemcell_os=${BASH_REMATCH[1]}
     else
       abort "Could not extract stemcell os type."

--- a/tasks/download-pivnet-stemcells/task.sh
+++ b/tasks/download-pivnet-stemcells/task.sh
@@ -62,7 +62,7 @@ function download_stemcell_version() {
   stemcell_os="$2"
 
   # check to see if we have a custom stemcell that matches first
-  if grab_custom_stemcell $stemcell_version $stemcell_os; then
+  if grab_custom_stemcell "$stemcell_version" "$stemcell_os"; then
     return 0
   fi 
 
@@ -86,6 +86,8 @@ function download_stemcell_version() {
 }
 
 function grab_custom_stemcell() {
+  local stemcell_path
+  echo "Version: $1 and OS: $2"
   stemcell_path="${cwd}/custom-stemcells/bosh-stemcell-${1}-${IAAS_TYPE}-esxi-${2}-go_agent.tgz" 
   echo Checking for custom stemcell at $stemcell_path
   if [ -e $stemcell_path ]; then

--- a/tasks/download-pivnet-stemcells/task.sh
+++ b/tasks/download-pivnet-stemcells/task.sh
@@ -39,12 +39,14 @@ function main() {
   # extract the stemcell version from the filename, e.g. 3312.21, and download the file from pivnet
   for stemcell in "${stemcells[@]}"; do
     local stemcell_version
-    stemcell_version=$(echo "$stemcell" | grep -Eo "[0-9]+(\.[0-9]+)?")
-    stemcell_os_regex="bosh-stemcell-[0-9]+\.[0-9]+-vsphere-esxi-([A-z0-9-]*)-go_agent.tgz"
-    if [[ $stemcell =~ $stemcell_os_regex ]]; then
-      stemcell_os=${BASH_REMATCH[1]}
+    local stemcell_os
+    local stemcell_re
+    stemcell_re="bosh-stemcell-([0-9]+\.[0-9]+)-vsphere-esxi-([A-z0-9-]*)-go_agent.tgz"
+    if [[ $stemcell =~ $stemcell_re ]]; then
+      stemcell_version=${BASH_REMATCH[1]}
+      stemcell_os=${BASH_REMATCH[2]}
     else
-      abort "Could not extract stemcell os type."
+      abort "Could not extract stemcell version and os type."
     fi
     download_stemcell_version "$stemcell_version" "$stemcell_os"
   done

--- a/tasks/download-pivnet-stemcells/task.sh
+++ b/tasks/download-pivnet-stemcells/task.sh
@@ -46,7 +46,7 @@ function main() {
     else
       abort "Could not extract stemcell os type."
     fi
-    download_stemcell_version $stemcell_version $stemcell_os
+    download_stemcell_version "$stemcell_version" "$stemcell_os"
   done
 }
 

--- a/tasks/download-pivnet-stemcells/task.sh
+++ b/tasks/download-pivnet-stemcells/task.sh
@@ -85,7 +85,7 @@ function download_stemcell_version() {
 }
 
 function grab_custom_stemcell() {
-  stemcell_path="custom-stemcells/bosh-stemcell-${1}-${IAAS_TYPE}-esxi-${2}-go_agent.tgz" 
+  stemcell_path="${cwd}/custom-stemcells/bosh-stemcell-${1}-${IAAS_TYPE}-esxi-${2}-go_agent.tgz" 
   echo Checking for custom stemcell at $stemcell_path
   if [ -e $stemcell_path ]; then
     echo Found custom stemcell and copying to download directory

--- a/tasks/download-pivnet-stemcells/task.sh
+++ b/tasks/download-pivnet-stemcells/task.sh
@@ -56,7 +56,7 @@ function download_stemcell_version() {
   stemcell_os="$2"
 
   # check to see if we have a custom stemcell that matches first
-  if [[ grab_custom_stemcell($stemcell_version,$stemcell_os) ]]; then
+  if [[ grab_custom_stemcell $stemcell_version $stemcell_os ]]; then
     return 0
   fi 
 

--- a/tasks/download-pivnet-stemcells/task.yml
+++ b/tasks/download-pivnet-stemcells/task.yml
@@ -22,7 +22,7 @@ image_resource:
 inputs:
   - name: pcf-pipelines
   - name: diagnostic-report
-  - name: custom-stemcells
+#  - name: custom-stemcells
 
 outputs:
   - name: stemcells

--- a/tasks/download-pivnet-stemcells/task.yml
+++ b/tasks/download-pivnet-stemcells/task.yml
@@ -22,6 +22,7 @@ image_resource:
 inputs:
   - name: pcf-pipelines
   - name: diagnostic-report
+  - name: custom-stemcells
 
 outputs:
   - name: stemcells

--- a/upgrade-ops-manager/vsphere/params.yml
+++ b/upgrade-ops-manager/vsphere/params.yml
@@ -35,3 +35,6 @@ dns: CHANGEME
 ntp: CHANGEME
 opsman_network: CHANGEME
 git_private_key:
+custom_stemcells_bucket_name: CHANGEME
+custom_stemcells_access_key: CHANGEME
+custom_stemcells_secret_key: CHANGEME

--- a/upgrade-ops-manager/vsphere/pipeline.yml
+++ b/upgrade-ops-manager/vsphere/pipeline.yml
@@ -44,6 +44,14 @@ resources:
     location: America/Los_Angeles
     days: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday]
 
+#- name: custom-stemcells
+#  type: s3
+#  source:
+#    regexp: bosh-stemcell-(?P<version>[0-9\.]*)-vsphere-esxi-(?P<os>[[:ascii:]]*)-go_agent.tgz
+#    bucket: {{custom_stemcells_bucket_name}}
+#    access_key_id: {{custom_stemcells_access_key}}
+#    secret_access_key: {{custom_stemcells_secret_key}}
+
 jobs:
 - name: regulator
   plan:
@@ -81,6 +89,7 @@ jobs:
       params:
         globs: ["*.ova"]
     - get: pcf-pipelines
+#    - get: custom-stemcells
 
   - task: wait-opsman-clear
     file: pcf-pipelines/tasks/wait-opsman-clear/task.yml


### PR DESCRIPTION
This PR adds in support for adding a custom-stemcell resource to the pipeline that pulls from S3.  This resource could be useful for adding custom built stemcells that aren't available on PivNet (particularly Windows stemcells on vSphere.)

The parts to add the custom-stemcell resource to the pipeline are mostly commented out, but the task script for download-pivnet-stemcells has been modified to optionally check for the "custom-stemcells" resource and use stemcells from there if they exist.

To use, one could either uncomment the commented sections in pipeline.yml and tasks/download-pivnet-stemcells/task.yml, and add the appropriate values into the params.yml.