### PR TITLE
Fix wait-opsman-clear task to only check the running status of the last change

### DIFF
--- a/tasks/wait-opsman-clear/task.sh
+++ b/tasks/wait-opsman-clear/task.sh
@@ -55,7 +55,7 @@ function main() {
 
       grep "action" changes-status.txt
       ACTION_STATUS=$?
-      grep "\"status\": \"running\"" running-status.txt
+      jq -e -r '.installations[0] | select(.status=="running")' running-status.txt >/dev/null
       RUNNING_STATUS=$?
 
       if [[ ${ACTION_STATUS} -ne 0 && ${RUNNING_STATUS} -ne 0 ]]; then


### PR DESCRIPTION
Unable to run upgrade-tile pipeline as it gets stuck on the wait-opsman-clear task due to previous old 'stuck' changes. This fix will get the first change only (the latest) from the running-status.txt

<img width="1635" alt="screen shot 2017-08-30 at 13 41 44" src="https://user-images.githubusercontent.com/4289960/29872892-b54143ea-8d91-11e7-9729-941975a5179e.png">
