### PR TITLE
DNS check needs to be based on params.yml

### DIFF
--- a/install-pcf/gcp/tasks/check-opsman-dns/task.sh
+++ b/install-pcf/gcp/tasks/check-opsman-dns/task.sh
@@ -3,7 +3,7 @@ set -e
 
 source "pcf-pipelines/functions/check_opsman_available.sh"
 
-opsman_available=$(check_opsman_available "opsman.${pcf_ert_domain}")
+opsman_available=$(check_opsman_available "opsman.${opsman_domain_or_ip_address}")
 if [[ $opsman_available != "available" ]]; then
   echo Could not reach opsman.${pcf_ert_domain}. Is DNS set up correctly?
   exit 1


### PR DESCRIPTION
We should use the value ${opsman_domain_or_ip_address} throughout the pipeline if it is configurable via params.