### PR TITLE
Adding product names for the tiles in the upgrade-tile params.yml

### DIFF
--- a/upgrade-tile/params.yml
+++ b/upgrade-tile/params.yml
@@ -48,6 +48,17 @@ product_slug: CHANGEME
 # This can be found in the .pivotal file's manifest for the product. This can
 # be found in the .pivotal file with the following:
 # `unzip -p p-rabbitmq-1.7.8.pivotal "metadata/*.yml" | head`
+# -------- | -------
+# PivNet Product | Product Name
+# Pivotal Cloud Foundry Metrics | apm
+# Pivotal Spring Cloud Services | p-spring-cloud-services
+# Redis For PCF | p-redis 
+# Pivotal Cloud Foundry Elastic Runtime | elastic-runtime
+# Pivotal Cloud Foundry Runtime for Windows | p-windows-runtime
+# MySQL for PCF | p-mysql
+# RabbitMQ for PCF | p-rabbitmq
+# Pivotal Cloud Cache | p-cloudcache
+# Pivotal Cloud Foundry JMX Bridge (Ops Metrics) | p-metrics 
 product_name: CHANGEME
 
 git_private_key:


### PR DESCRIPTION
Adding the product names for the tiles in the upgrade-tile params.yml so its easy for operators to set the pipeline