### PR TITLE
Changed instance type for opsman from m3.large to m4.large

### DIFF
--- a/install-pcf/aws/terraform/variables.tf
+++ b/install-pcf/aws/terraform/variables.tf
@@ -30,7 +30,7 @@ variable "opsman_allow_https_cidr_ranges" {
 
 variable "opsman_instance_type" {
     description = "Instance Type for OpsMan"
-    default = "m3.large"
+    default = "m4.large"
 }
 variable "nat_instance_type" {
     description = "Instance Type for NAT instances"


### PR DESCRIPTION
This is to address issue with instance type, closes https://github.com/pivotal-cf/pcf-pipelines/issues/193