### PR TITLE
update stemcell flag to download azure stemcell

### DIFF
--- a/upgrade-ops-manager/azure/pipeline.yml
+++ b/upgrade-ops-manager/azure/pipeline.yml
@@ -117,7 +117,7 @@ jobs:
     file: pcf-pipelines/tasks/download-pivnet-stemcells/task.yml
     params:
       API_TOKEN: {{pivnet_token}}
-      IAAS_TYPE: aws
+      IAAS_TYPE: azure
 
   - task: restore-stemcells
     file: pcf-pipelines/tasks/restore-stemcells/task.yml


### PR DESCRIPTION
update stemcell flag to download azure stemcell. Currently it's pulling the AWS lite stemcell for this azure pipeline and  will result in failed pipeline. 