### PR TITLE
make the opsman domain consistent to one parameter

### DIFF
--- a/install-pcf/aws/pipeline.yml
+++ b/install-pcf/aws/pipeline.yml
@@ -57,7 +57,7 @@ jobs:
   serial_groups: [terraform]
   plan:
   - aggregate:
-    - get: pcf-pipelines 
+    - get: pcf-pipelines
     - get: terraform-state
     - get: pivnet-opsmgr
       params:
@@ -163,7 +163,7 @@ jobs:
   serial_groups: [opsman]
   plan:
   - aggregate:
-    - get: pcf-pipelines 
+    - get: pcf-pipelines
     - get: terraform-state
       trigger: true
       passed: [create-infrastructure]
@@ -177,7 +177,7 @@ jobs:
   - task: configure-director
     file: pcf-pipelines/install-pcf/aws/tasks/config-director/task.yml
     params:
-      ERT_DOMAIN: {{ERT_DOMAIN}}
+      OPSMAN_DOMAIN_OR_IP_ADDRESS: {{opsman_domain_or_ip_address}}
       OPSMAN_USER: {{OPSMAN_USER}}
       OPSMAN_PASSWORD: {{OPSMAN_PASSWORD}}
       AWS_KEY_NAME: {{TF_VAR_aws_key_name}}
@@ -215,7 +215,7 @@ jobs:
   serial_groups: [opsman]
   plan:
   - aggregate:
-    - get: pcf-pipelines 
+    - get: pcf-pipelines
     - get: pivnet-product
       resource: pivnet-elastic-runtime
       params:
@@ -246,7 +246,7 @@ jobs:
   serial_groups: [opsman]
   plan:
   - aggregate:
-    - get: pcf-pipelines 
+    - get: pcf-pipelines
     - get: terraform-state
       trigger: true
       passed: [upload-ert]

--- a/install-pcf/aws/tasks/config-director/task.sh
+++ b/install-pcf/aws/tasks/config-director/task.sh
@@ -225,7 +225,7 @@ for json in "${jsons[@]}"; do
 done
 
 om-linux \
-  --target https://opsman.$ERT_DOMAIN \
+  --target https://${OPSMAN_DOMAIN_OR_IP_ADDRESS} \
   --skip-ssl-validation \
   --username $OPSMAN_USER \
   --password $OPSMAN_PASSWORD \

--- a/install-pcf/aws/tasks/config-director/task.yml
+++ b/install-pcf/aws/tasks/config-director/task.yml
@@ -6,10 +6,10 @@ image_resource:
   source:
     repository: czero/cflinuxfs2
 inputs:
-  - name: pcf-pipelines 
+  - name: pcf-pipelines
   - name: terraform-state
 params:
-  ERT_DOMAIN:
+  OPSMAN_DOMAIN_OR_IP_ADDRESS:
   OPSMAN_USER:
   OPSMAN_PASSWORD:
   AWS_KEY_NAME:


### PR DESCRIPTION
The AWS config auth is using  OPSMAN_DOMAIN_OR_IP_ADDRESS

While the config director is using opsman.${ert_domain}

This will cause the deployment failure if the two parameters configured not match
