### PR TITLE
Private git key is required and needs to change

### DIFF
--- a/install-pcf/gcp/params.yml
+++ b/install-pcf/gcp/params.yml
@@ -25,7 +25,8 @@ gcp_storage_secret_key: CHANGEME
 
 terraform_statefile_bucket:
 
-git_private_key:
+git_private_key: |
+  CHANGEME
 
 # Pivotal Network token: https://network.pivotal.io/users/dashboard/edit-profile
 pivnet_token: CHANGEME


### PR DESCRIPTION
The `bootstrap-terraform-state` will fail without adding a private key.