### PR TITLE
store terraform.tfstate in configured region rather than s3 default

### DIFF
--- a/install-pcf/aws/pipeline.yml
+++ b/install-pcf/aws/pipeline.yml
@@ -14,6 +14,7 @@ resources:
     secret_access_key: {{TF_VAR_aws_secret_key}}
     endpoint: {{S3_ENDPOINT}}
     bucket: {{S3_OUTPUT_BUCKET}}
+    region_name: {{TF_VAR_aws_region}}
     versioned_file: terraform.tfstate
 
 - name: pivnet-elastic-runtime

--- a/tasks/create-initial-terraform-state/task.sh
+++ b/tasks/create-initial-terraform-state/task.sh
@@ -22,7 +22,7 @@ set +e
 echo $files | grep terraform.tfstate
 if [ "$?" -gt "0" ]; then
   echo "{\"version\": 3}" > terraform.tfstate
-  aws s3 --endpoint-url $S3_ENDPOINT cp terraform.tfstate "s3://${S3_BUCKET_TERRAFORM}/terraform.tfstate"
+  aws s3 --endpoint-url $S3_ENDPOINT --region $S3_REGION cp terraform.tfstate "s3://${S3_BUCKET_TERRAFORM}/terraform.tfstate"
   set +x
   if [ "$?" -gt "0" ]; then
     echo "Failed to upload empty tfstate file"


### PR DESCRIPTION
Updating the `S3_ENDPOINT` in install-pcf/aws/params.yml to a different region endpoint (e.g. https://s3-us-west-2.amazonaws.com) results in the following error when running the `bootstrap-terraform-state` job: 

> BucketRegionError: incorrect region, the bucket is not in 'us-east-1' region.  

These changes use the `TF_VAR_aws_region` value to ensure the state file can be stored in a non default S3 region.