### PR TITLE
fix jq query for unstaged product

### DIFF
--- a/tasks/stage-product/task.sh
+++ b/tasks/stage-product/task.sh
@@ -42,8 +42,7 @@ UNSTAGED_ALL=$(jq -n --argjson available "$AVAILABLE" --argjson staged "$STAGED"
   '$available - ($staged | map({"name": .type, "product_version": .product_version}))')
 
 UNSTAGED_PRODUCT=$(
-jq -n "$UNSTAGED_ALL" \
-  "map(select(.name == \"$PRODUCT_NAME\")) | map(select(.product_version|startswith(\"$desired_version\")))"
+jq -n "$UNSTAGED_ALL | map(select(.name == \"$PRODUCT_NAME\")) | map(select(.product_version|startswith(\"$desired_version\")))"
 )
 
 # There should be only one such unstaged product.


### PR DESCRIPTION
The previous query was missing a | character and therefore
returned the input unfiltered.  As a result, more than one
product is returned and the pipeline fails.