### PR TITLE
Enables the re-run of 'create-infrastructure' whenever there is a change to the ssl cert for GCP

### DIFF
--- a/install-pcf/gcp/terraform/loadbalancing_http.tf
+++ b/install-pcf/gcp/terraform/loadbalancing_http.tf
@@ -46,10 +46,14 @@ resource "google_compute_target_https_proxy" "https_lb_proxy" {
 }
 
 resource "google_compute_ssl_certificate" "ssl-cert" {
-  name        = "${var.prefix}-lb-cert"
+  name_prefix = "${var.prefix}-lb-cert-"
   description = "user provided ssl private key / ssl certificate pair"
   certificate = "${var.pcf_ert_ssl_cert}"
   private_key = "${var.pcf_ert_ssl_key}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "google_compute_http_health_check" "cf" {


### PR DESCRIPTION
When you try to run the create-infrastructure after it has already run with `pcf_ert_ssl_cert: generate`, the job fails with:
```
 * google_compute_ssl_certificate.ssl-cert (destroy): 1 error(s) occurred:

* google_compute_ssl_certificate.ssl-cert: Error deleting ssl certificate: googleapi: Error 400: The ssl_certificate resource 'projects/<PROJECT_NAME>/global/sslCertificates/fly-cf-lb-cert' is already being used by 'projects/<PROJECT_NAME>/global/targetHttpsProxies/fly-cf-https-proxy', resourceInUseByAnotherResource
```

It should create a new cert before trying to delete the old one, else it fails, as stated here:
https://www.terraform.io/docs/providers/google/r/compute_ssl_certificate.html#using-with-target-https-proxies

This PR should correct this use case and also whenever you want to update your certificates afterwards with a signed one.