### PR TITLE
Fix when routing_http_disable is false for GCP

### DIFF
--- a/install-pcf/gcp/terraform/loadbalancing_http.tf
+++ b/install-pcf/gcp/terraform/loadbalancing_http.tf
@@ -3,6 +3,11 @@ resource "google_compute_instance_group" "ert-http-lb" {
   name        = "${var.prefix}-http-lb"
   description = "terraform generated pcf instance group that is multi-zone for http/https load balancing"
   zone        = "${element(list(var.gcp_zone_1,var.gcp_zone_2,var.gcp_zone_3), count.index)}"
+
+  named_port {
+    name = "http"
+    port = 80
+  }
 }
 
 resource "google_compute_backend_service" "ert_http_lb_backend_service" {


### PR DESCRIPTION
Duet-Pull Request from : @ckunst & @RomRider

While deploying pcf on GCP using the install-pcf pipeline, there is a missing named_port in the ERT resource groups which are created by terraform.

If this named_port is not created, the GCP load balancer is not able to forward traffic to the backends on the port defined in the GCP LB itself:
```
resource "google_compute_backend_service" "ert_http_lb_backend_service" {
  name        = "${var.prefix}-http-lb-backend"
  port_name   = "http"
  protocol    = "HTTP"
  timeout_sec = 30
  enable_cdn  = false
```

This fix only works when the `routing_http_disable` parameter is set to `false`.