### PR TITLE
Temporary fix for disabling http on the GCP LB

### DIFF
--- a/install-pcf/gcp/params.yml
+++ b/install-pcf/gcp/params.yml
@@ -53,7 +53,10 @@ pcf_ert_ssl_key:
 haproxy_forward_tls: enable # If enabled HAProxy will forward all requests to the router over TLS (enable|disable)
 haproxy_backend_ca:         # HAProxy will use the CA provided to verify the certificates provided by the router.
 
-routing_disable_http: false
+# disabling http on gorouter is not yet supported because health checks can't be done in HTTPS
+# routing_disable_http: false
+# In the meantime, we only disable http on the GCP load balancer
+disable_http_on_gcp_lb: false
 
 # An ordered, colon-delimited list of Golang supported TLS cipher suites in OpenSSL format.
 # Operators should verify that these are supported by any clients or downstream components that will initiate TLS handshakes with the Router/HAProxy.

--- a/install-pcf/gcp/pipeline.yml
+++ b/install-pcf/gcp/pipeline.yml
@@ -144,6 +144,8 @@ jobs:
       DB_LOCKET_PASSWORD: {{db_locket_password}}
       DB_SILK_USERNAME: {{db_silk_username}}
       DB_SILK_PASSWORD: {{db_silk_password}}
+      # Temporary fix for gorouter not supporting https health checks
+      DISABLE_HTTP_ON_GCP_LB: {{disable_http_on_gcp_lb}}
 
 - name: configure-director
   serial_groups: [opsman]
@@ -295,7 +297,7 @@ jobs:
       HAPROXY_BACKEND_CA: {{haproxy_backend_ca}}
       ROUTER_TLS_CIPHERS: {{router_tls_ciphers}}
       HAPROXY_TLS_CIPHERS: {{haproxy_tls_ciphers}}
-      routing_disable_http: {{routing_disable_http}}
+      routing_disable_http: false
       INTERNET_CONNECTED: {{internet_connected}}
       CONTAINER_NETWORKING_NW_CIDR: {{container_networking_nw_cidr}}
       # aws specific

--- a/install-pcf/gcp/tasks/create-infrastructure/task.sh
+++ b/install-pcf/gcp/tasks/create-infrastructure/task.sh
@@ -59,6 +59,7 @@ terraform plan \
   -var "db_locket_password=${DB_LOCKET_PASSWORD}" \
   -var "db_silk_username=${DB_SILK_USERNAME}" \
   -var "db_silk_password=${DB_SILK_PASSWORD}" \
+  -var "disable_http_on_gcp_lb=${DISABLE_HTTP_ON_GCP_LB}" \
   -out terraform.tfplan \
   -state terraform-state/terraform.tfstate \
   pcf-pipelines/install-pcf/gcp/terraform

--- a/install-pcf/gcp/terraform/loadbalancing_http.tf
+++ b/install-pcf/gcp/terraform/loadbalancing_http.tf
@@ -73,6 +73,8 @@ resource "google_compute_global_forwarding_rule" "cf-http" {
   ip_address = "${google_compute_global_address.pcf.address}"
   target     = "${google_compute_target_http_proxy.http_lb_proxy.self_link}"
   port_range = "80"
+
+  count = "${var.disable_http_on_gcp_lb == "false" ? 1 : 0}"
 }
 
 resource "google_compute_global_forwarding_rule" "cf-https" {

--- a/install-pcf/gcp/terraform/variables.tf
+++ b/install-pcf/gcp/terraform/variables.tf
@@ -44,3 +44,6 @@ variable "db_locket_username" {}
 variable "db_locket_password" {}
 variable "db_silk_username" {}
 variable "db_silk_password" {}
+variable "disable_http_on_gcp_lb" {
+  default = false
+}


### PR DESCRIPTION
Duet PR: @ckunst & @RomRider

When using GCP load balancers, the health check protocol needs to be the same as the backend protocol. That means if we want to disable http on gorouter, we will need to do the health checks against the gorouter in https, which is not possible right now. The gorouter only supports http/8080 for health-checks at the moment.
We opened an issue on the gorouter github: https://github.com/cloudfoundry/gorouter/issues/199

This fix is a workaround enabling the deployment of PCF on GCP with http/80 disabled on the GCP load balancers while still having the http enabled on the gorouter. The parameter `routing_disable_http` is forced to false and a new parameter `disable_http_on_gcp_lb` was introduced, which is `false` by default.

We suggest to keep the health-check as-is in order to support canary upgrades of ERT.