### PR TITLE
Expand on what exactly is required for the pcf_ert_domain

### DIFF
--- a/install-pcf/gcp/params.yml
+++ b/install-pcf/gcp/params.yml
@@ -42,6 +42,8 @@ opsman_trusted_certs: |
 
 # Elastic Runtime Domain
 pcf_ert_domain: CHANGEME # This is the domain you will access ERT with
+pcf_ert_domain: CHANGEME # This is the top level domain that ERT apps and services will be accessible with
+                         # e.g.: if the apps domain is apps.pcf.example.org then pcf_ert_domain should be pcf.example.org
 opsman_domain_or_ip_address: CHANGEME # This should be your pcf_ert_domain with "opsman." as a prefix
 
 # Elastic Runtime SSL configuration


### PR DESCRIPTION
@sahilm @eamonryan @chentom88 and I were exploring `pcf-pipelines` as part of PRE summit in Dublin and we came across this configuration item. We haven't heard this domain referred to as the ERT Domain before.

Perhaps this isn't as much of an issue for those new to PCF, but we thought explaining it via an example makes it a tiny bit clearer.