### PR TITLE
Added pcf_pipelines_version param to gcp pcf-installer

### DIFF
--- a/install-pcf/gcp/params.yml
+++ b/install-pcf/gcp/params.yml
@@ -1,3 +1,8 @@
+# The version of pcf-pipelines used
+pcf_pipelines_version: CHANGEME # This should be the same as the git reference checked out
+                                # on the machine that you're editing this file on
+                                # e.g.: v0.19.2
+
 # GCP project to create the infrastructure in
 gcp_project_id: CHANGEME
 

--- a/install-pcf/gcp/pipeline.yml
+++ b/install-pcf/gcp/pipeline.yml
@@ -18,6 +18,7 @@ resources:
   source:
     uri: git@github.com:pivotal-cf/pcf-pipelines.git
     branch: master
+    tag_filter: {{pcf_pipelines_version}}
     private_key: {{git_private_key}}
 
 - name: terraform-state


### PR DESCRIPTION
* We ran into an issue where `master` had diverged enough that cloning
  that reference in the pipeline broke `check-opsmand-dns` job.

@sahilm @eamonryan @chentom88 and I had a failing pipeline because one of the underlying tasks changed its interface between [v0.19.2 and master](https://github.com/pivotal-cf/pcf-pipelines/compare/v0.19.2...master). It appears to be related to [this change](https://github.com/pivotal-cf/pcf-pipelines/commit/c9af0b1714b568481e7708f6d794d18af84e932e#diff-42be3575a3acbd97ebbd5d491784a60c).

**note** I added this param to the top of the file, but not 100% where in `params.yml` it should live.