### PR TITLE
Fix available_stemcells to print with newlines

### DIFF
--- a/operations/create-install-pcf-vsphere-offline-pipeline.yml
+++ b/operations/create-install-pcf-vsphere-offline-pipeline.yml
@@ -147,7 +147,7 @@
 
                 stemcell_to_download=$(
                   set +e
-                  echo $available_stemcells | grep $stemcell_version
+                  echo "$available_stemcells" | grep $stemcell_version
                   set -e
                 )
 


### PR DESCRIPTION
`echo $available_stemcells` will print all available S3 stemcells in one line separated by spaces, this causes the subsequent grep to return more than one result if there are multiple stemcells available which will cause the download operation to fail.

`echo "$available_stemcells"` with the quotes will print the results on separate lines allowing the `grep` to work properly