### PR TITLE
Download stemcell from bosh.io task fixes

### DIFF
--- a/tasks/download-boshio-stemcells/task.sh
+++ b/tasks/download-boshio-stemcells/task.sh
@@ -27,7 +27,7 @@ function main() {
   local bosh_io_stemcells=($( (jq --raw-output '.added_products.deployed[] | select (.name | contains("p-bosh") | not) | select (.stemcell | contains("ubuntu") | not) |.stemcell' | \
     sort -u) < "$diag_report"))
   if [ ${#bosh_io_stemcells[@]} -eq 0 ]; then
-    echo "No installed products found that require a ubuntu stemcell"
+    echo "No installed products found that require a non-ubuntu stemcell"
     exit 0
   fi
 

--- a/tasks/download-boshio-stemcells/task.sh
+++ b/tasks/download-boshio-stemcells/task.sh
@@ -17,8 +17,6 @@ set -eu
 # limitations under the License.
 
 function main() {
-  if [ -z "$API_TOKEN" ]; then abort "The required env var API_TOKEN was not set for pivnet"; fi
-
   local cwd=$PWD
   local download_dir="${cwd}/stemcells"
   local diag_report="${cwd}/diagnostic-report/exported-diagnostic-report.json"

--- a/tasks/download-boshio-stemcells/task.sh
+++ b/tasks/download-boshio-stemcells/task.sh
@@ -36,10 +36,24 @@ function main() {
   # extract the stemcell version from the filename, e.g. 3312.21, and download the file from pivnet
   for stemcell in "${bosh_io_stemcells[@]}"; do
 
-    local version=$(echo "$stemcell" | grep -Eo "[0-9]+\.[0-9]+")
-    local stemcell_type=bosh-$(ruby -e "puts '$stemcell'.split('$version-')[1].split('.')[0]")
+    echo "${stemcell}"
 
-    curl -L -J -o ${download_dir}/${stemcell} https://bosh.io/d/stemcells/${stemcell_type}?v=${version}
+    if [[ $stemcell =~ ([0-9]+\.[0-9]+) ]]; then
+      local version="${BASH_REMATCH[1]}"
+    else
+      abort "Couldn't find a stemcell version"
+    fi
+
+    if [[ $stemcell =~ $version-(.+).tgz ]]; then
+      local stemcell_type="bosh-${BASH_REMATCH[1]}"
+    else
+      abort "Couldn't find a stemcell type"
+    fi
+
+    echo "${stemcell_type}"
+    echo "${version}"
+
+    wget -O "${download_dir}/${stemcell}" "https://bosh.io/d/stemcells/${stemcell_type}?v=${version}"
   done
 }
 

--- a/tasks/download-boshio-stemcells/task.sh
+++ b/tasks/download-boshio-stemcells/task.sh
@@ -21,7 +21,7 @@ function main() {
   local download_dir="${cwd}/stemcells"
   local diag_report="${cwd}/diagnostic-report/exported-diagnostic-report.json"
 
-  cp ${cwd}/pivnet-stemcells/* ${download_dir}
+  cp -a "${cwd}/pivnet-stemcells/." "${download_dir}"
 
   # get the deduplicated stemcell filename for each deployed release (skipping p-bosh)
   local bosh_io_stemcells=($( (jq --raw-output '.added_products.deployed[] | select (.name | contains("p-bosh") | not) | select (.stemcell | contains("ubuntu") | not) |.stemcell' | \

--- a/tasks/download-boshio-stemcells/task.yml
+++ b/tasks/download-boshio-stemcells/task.yml
@@ -27,8 +27,5 @@ inputs:
 outputs:
   - name: stemcells
 
-params:
-  API_TOKEN:
-
 run:
   path: pcf-pipelines/tasks/download-boshio-stemcells/task.sh


### PR DESCRIPTION
I still need to validate this is working end to end in a pipeline. I fixed some missing error checks, messages, etc.

- Remove API_TOKEN from download-boshio-stemcell task
- Add fix for copying an empty pivnet-stemcells dir
- Add correct error message if no stemcells are found
- Remove Ruby requirement from bosh stemcell task
- Use wget instead of curl so 404 or other errors fail the task