### PR TITLE
add ops files for colocated credhub sample

### DIFF
--- a/docs/credhub-integration.md
+++ b/docs/credhub-integration.md
@@ -70,9 +70,9 @@ This integration approach provides a CredHub server that is dedicated to the Con
   - [**Cloud Config**](https://bosh.io/docs/update-cloud-config.html) set to the Bosh Director to define network, disk and VM settings.
 
 
-1. Create and update your **Concourse deployment YML file** containing the CredHub jobs defined as part of the Concourse's `web` VM. See this [deployment file](samples/concourse-with-credhub.yml) as an example for a starting point.
+1. Create and update your **Concourse deployment YML file** containing the CredHub jobs defined as part of the Concourse's `web` VM. See this [deployment file](samples/concourse-with-credhub.yml) as an example for a starting point, or use the [operations files](samples/colocated-credhub/ops) provided in this repo to transform an existing manifest.
 
-3. Configure [concourse-with-credhub-params.yml](samples/concourse-with-credhub-params.yml) with the corresponding values for your deployment.
+2. Configure [concourse-with-credhub-params.yml](samples/concourse-with-credhub-params.yml) with the corresponding values for your deployment.
 
 3. Upload required release files to the Bosh Director.
    - [Concourse](https://bosh.io/d/github.com/concourse/concourse)

--- a/docs/samples/colocated-credhub-ops/README.md
+++ b/docs/samples/colocated-credhub-ops/README.md
@@ -1,0 +1,31 @@
+# CredHub + Concourse
+
+This directory contains BOSH [operations files](https://bosh.io/docs/cli-ops-files.html)
+to set up CredHub integration with Concourse:
+
+- `add-credhub-to-atc.yml`: Colocates CredHub + UAA on the Concourse ATC instances
+- `replace-vault-with-credhub`: Replace Concourse's Vault configuration with CredHub
+
+The operations are split into separate files to allow for a two-phased migration
+from Vault to CredHub.  Some teams may decide to deploy CredHub alongside Concourse
+while still using Vault as a first step.  This gives the team a chance to learn
+CredHub, verify that Concourse is still operational with a colocated CredHub and
+UAA, and load CredHub with secrets prior to disabling the Vault integration.
+
+## Usage
+
+Upload the [CredHub](http://bosh.io/releases/github.com/pivotal-cf/credhub-release?all=1)
+and [UAA](http://bosh.io/releases/github.com/cloudfoundry/uaa-release?all=1) releases
+to your BOSH director.
+
+Then simply define the required variables and apply the operations files with `-o <file>`
+as part of the `bosh deploy` command (CLI v2 only).  Variables can be defined in a YAML
+file along with the `-l` flag, or specified inline on the command line with `-v VAR=VALUE`.
+
+You may also use `bosh int` to view the interpolated manifest:
+
+```
+$ bosh int concourse.yml -o add-credhub-to-atc.yml -o replace-vault-with-credhub.yml
+```
+
+**Note:** CredHub integration requires Concourse 3.5.0 or later.

--- a/docs/samples/colocated-credhub-ops/add-credhub-to-atcs.yml
+++ b/docs/samples/colocated-credhub-ops/add-credhub-to-atcs.yml
@@ -1,0 +1,232 @@
+# add missing variables
+- type: replace
+  path: /variables?/name=atc-db-password?
+  value:
+    name: atc-db-password
+    type: password
+- type: replace
+  path: /variables?/name=credhub-encryption-password?
+  value:
+    name: credhub-encryption-password
+    type: password
+    options:
+      length: 40
+- type: replace
+  path: /variables?/name=concourse-ca?
+  value:
+    name: concourse-ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: Concourse CA
+- type: replace
+  path: /variables?/name=concourse-tls?
+  value:
+    name: concourse-tls
+    type: certificate
+    options:
+      ca: concourse-ca
+      common_name: ((concourse_host))
+      alternative_names:
+      - ((concourse_host))
+- type: replace
+  path: /variables?/name=credhub-db-password?
+  value:
+    name: credhub-db-password
+    type: password
+- type: replace
+  path: /variables?/name=uaa-jwt?
+  value:
+    name: uaa-jwt
+    type: rsa
+    options:
+      key_length: 4096
+- type: replace
+  path: /variables?/name=uaa-users-admin?
+  value:
+    name: uaa-users-admin
+    type: password
+- type: replace
+  path: /variables?/name=uaa-admin?
+  value:
+    name: uaa-admin
+    type: password
+- type: replace
+  path: /variables?/name=uaa-login?
+  value:
+    name: uaa-login
+    type: password
+- type: replace
+  path: /variables?/name=uaa-credhub-admin?
+  value:
+    name: uaa-credhub-admin
+    type: password
+- type: replace
+  path: /variables?/name=uaa-db-admin?
+  value:
+    name: uaa-db-admin
+    type: password
+- type: replace
+  path: /variables?/name=uaa-db-password?
+  value:
+    name: uaa-db-password
+    type: password
+- type: replace
+  path: /variables?/name=concourse_to_credhub_secret?
+  value:
+    name: concourse_to_credhub_secret
+    type: password
+- type: replace
+  path: /variables?/name=credhub_cli_password?
+  value:
+    name: credhub_cli_password
+    type: password
+- type: replace
+  path: /variables?/name=concourse_client_secret?
+  value:
+    name: concourse_client_secret
+    type: password
+- type: replace
+  path: /variables?/name=main-team-password?
+  value:
+    name: main-team-password
+    type: password
+
+# add UAA and credhub releases
+- type: replace
+  path: /releases/-
+  value:
+    name: uaa
+    version: latest
+- type: replace
+  path: /releases/-
+  value:
+    name: credhub
+    version: latest
+
+# update DB instance to include credhub and uaa databases
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/databases/-
+  value:
+    name: credhub
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/databases/-
+  value:
+    name: uaa
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/roles/-
+  value:
+    name: credhub
+    password: ((credhub-db-password))
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/roles/-
+  value:
+    name: uaa
+    password: ((uaa-db-password))
+
+# add credhub job to ATC instance group
+- type: replace
+  path: /instance_groups/name=web/jobs/-
+  value:
+    name: credhub
+    release: credhub
+    properties:
+      credhub:
+        port: 8844
+        authentication:
+          uaa:
+            url: *uaa-url
+            verification_key: ((uaa-jwt.public_key))
+            ca_certs:
+            - ((concourse-tls.ca))
+        data_storage:
+          type: postgres
+          host: ((db_ip))
+          port: 5432
+          username: credhub
+          password: ((credhub-db-password))
+          database: credhub
+          require_tls: false
+        tls: ((concourse-tls))
+        log_level: info
+        encryption:
+          keys:
+          - provider_name: int
+            encryption_password: ((credhub-encryption-password))
+            active: true
+          providers:
+          - name: int
+            type: internal
+
+# add UAA job to ATC instance group
+- type: replace
+  path: /instance_groups/name=web/jobs/-
+  value:
+    name: uaa
+    release: uaa
+    properties:
+      uaa:
+        url: &uaa-url "https://((concourse_host)):8443"
+        port: -1
+        scim:
+          users:
+          - name: admin
+            password: ((uaa-users-admin))
+            groups:
+            - scim.write
+            - scim.read
+            - bosh.admin
+            - credhub.read
+            - credhub.write
+        clients:
+          credhub_cli:
+            override: true
+            authorized-grant-types: password,refresh_token
+            scope: credhub.read,credhub.write
+            authorities: uaa.resource
+            access-token-validity: 1200
+            refresh-token-validity: 3600
+            secret: ""
+          concourse_to_credhub:
+            override: true
+            authorized-grant-types: client_credentials
+            scope: ""
+            authorities: credhub.read,credhub.write
+            access-token-validity: 30
+            refresh-token-validity: 3600
+            secret: ((concourse_to_credhub_secret))
+        admin: {client_secret: ((uaa-admin))}
+        login: {client_secret: ((uaa-login))}
+        zones: {internal: {hostnames: []}}
+        sslCertificate: ((concourse-tls.certificate))
+        sslPrivateKey: ((concourse-tls.private_key))
+        jwt:
+          revocable: true
+          policy:
+            active_key_id: key-1
+            keys:
+              key-1:
+                signingKey: ((uaa-jwt.private_key))
+      uaadb:
+        address: ((db_ip))
+        port: 5432
+        db_scheme: postgresql
+        databases:
+        - tag: uaa
+          name: uaa
+        roles:
+        - tag: admin
+          name: uaa
+          password: ((uaa-db-password))
+      login:
+        saml:
+          serviceProviderCertificate: ((concourse-tls.certificate))
+          serviceProviderKey: ((concourse-tls.private_key))
+          serviceProviderKeyPassword: ""
+
+# modify update settings to give UAA enough time to start up
+- type: replace
+  path: /update/canary_watch_time
+  value: 30000-1200000
+- type: /update/update_watch_time
+  value: 5000-1200000

--- a/docs/samples/colocated-credhub-ops/replace-vault-with-credhub.yml
+++ b/docs/samples/colocated-credhub-ops/replace-vault-with-credhub.yml
@@ -1,0 +1,14 @@
+# remove existing vault configuration
+- type: remove
+  path: /instance_groups/name=web/jobs/name=atc/properties/vault
+
+# add credhub configuration
+- type: replace
+  path: /instance_groups/name=web/jobs/name=atc/properties/credhub?
+  value:
+    url: https://((concourse_host)):8844
+    tls:
+      ca_cert: ((concourse-ca))
+      insecure_skip_verify: ((credhub_insecure_skip_verify))
+    client_id: concourse_to_credhub
+    client_secret: ((concourse_to_credhub_secret))


### PR DESCRIPTION
Add operations files that can take an existing Concourse manifest (potentially with Vault integration) and deploy Credhub+UAA per our "colocated credhub" sample.

/cc @lsilvapvt 