### PR TITLE
Lock down pyOpenSSL version

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -40,7 +40,7 @@ pip install awscli && \
 
 # Openstack Client
 apt-get install -y --no-install-recommends libffi-dev && \
-pip install cryptography==2.0.3 python-openstackclient pytz python-neutronclient && \
+pip install cryptography==2.0.3 pyOpenSSL==17.4.0 python-openstackclient pytz python-neutronclient && \
 
 # Azure Client
 echo "deb https://packages.microsoft.com/repos/azure-cli/ wheezy main" | sudo tee /etc/apt/sources.list.d/azure-cli.list && \


### PR DESCRIPTION
[since 17.5.0 requires cryptography 2.1.4](https://github.com/pyca/pyopenssl/blob/master/CHANGELOG.rst#backward-incompatible-changes-1)

fixes #255 