### PR TITLE
Enable S3 encryption by default

### DIFF
--- a/install-pcf/aws/terraform/eips.tf
+++ b/install-pcf/aws/terraform/eips.tf
@@ -1,0 +1,14 @@
+resource "aws_eip" "nat_az1" {
+  instance = "${aws_instance.nat_az1.id}"
+  vpc  = true
+}
+
+resource "aws_eip" "nat_az2" {
+  instance = "${aws_instance.nat_az2.id}"
+  vpc  = true
+}
+
+resource "aws_eip" "nat_az3" {
+  instance = "${aws_instance.nat_az3.id}"
+  vpc  = true
+}

--- a/install-pcf/aws/terraform/outputs.tf
+++ b/install-pcf/aws/terraform/outputs.tf
@@ -28,6 +28,20 @@ output "opsman_eip" {
 output "opsman_identifier" {
     value = "${aws_instance.opsmman_az1.tags.Name}"
 }
+
+# NAT
+output "nat_az1_eip" {
+    value = "${aws_eip.nat_az1.public_ip}"
+}
+
+output "nat_az2_eip" {
+    value = "${aws_eip.nat_az2.public_ip}"
+}
+
+output "nat_az3_eip" {
+    value = "${aws_eip.nat_az3.public_ip}"
+}
+
 # s3 buckets
 output "s3_pcf_bosh" {
     value = "${aws_s3_bucket.bosh.bucket}"


### PR DESCRIPTION
Note this uses a relatively new field in the terraform AWS provider `aws_s3_bucket` resource so it may need to be updated in your docker images.