### PR TITLE
Add sample for email notification yaml-patch operation

### DIFF
--- a/docs/yaml-patch-examples.md
+++ b/docs/yaml-patch-examples.md
@@ -5,9 +5,9 @@
 - [Add a task to a job](#add-task-to-job)
 - [Add a task to a job after a specific task](#add-task-to-job-after-another-task)
 - [Replace a resource definition in the pipeline YML](#replace-resource-definition)
+- [Add email notifications to an existing pipeline](#add-email-nofitications)
 - [Change the trigger flag of a job resource](#change-trigger-flag)
 - [Additional operations samples](#additional-operations-samples)
-
 
 ---
 
@@ -146,6 +146,25 @@ resources:
     product_slug: pcf-automation  
     product_version: ~    
 ```  
+
+
+---
+
+
+### <a name="add-email-nofitications"> Add email notification to an existing pipeline
+
+For a sample on how to add email notification to all jobs of a pipeline (e.g. for [upgrade-tile.yml](https://github.com/pivotal-cf/pcf-pipelines/blob/master/upgrade-tile/pipeline.yml)), see  [add-email-nofication-to-upgrade-tile.yml](https://github.com/pivotal-cf/pcf-pipelines/blob/master/operations/add-email-nofication-to-upgrade-tile.yml).
+
+The operations file injects entries to `resource_types` and `resources` arrays for the email resource and then adds email notification actions for *success* and *failure* scenarios to the pipeline jobs.
+
+1. Source YAML:  [upgrade-tile.yml](https://github.com/pivotal-cf/pcf-pipelines/blob/master/upgrade-tile/pipeline.yml)  
+
+2. Operations file:  [add-email-nofication-to-upgrade-tile.yml](https://github.com/pivotal-cf/pcf-pipelines/blob/master/operations/add-email-nofication-to-upgrade-tile.yml)  
+
+3. Execute yaml-patch command  
+   `cat upgrade-tile.yml | yaml-patch -o add-email-nofication-to-upgrade-tile.yml > upgrade-tile-with-notifications.yml`    
+
+4. Resulting patched file: `upgrade-tile-with-notifications.yml`  
 
 
 ---

--- a/operations/add-email-nofication-to-upgrade-tile.yml
+++ b/operations/add-email-nofication-to-upgrade-tile.yml
@@ -1,0 +1,57 @@
+### EMAIL RESOURCE TYPE definition - See the resource's documentation for more details.
+### https://github.com/pivotal-cf/email-resource
+- op: add
+  path: /resource_types/-
+  value:
+    name: email
+    type: docker-image
+    source:
+      repository: pcfseceng/email-resource
+
+### EMAIL RESOURCE definition - update the source object's parameters accordingly
+### See the resource's documentation for more details:
+### https://github.com/pivotal-cf/email-resource
+- op: add
+  path: /resources/-
+  value:
+    name: send-email
+    type: email
+    source:
+      smtp:
+        host: smtp.example.com
+        port: "587" # this must be a string
+        username: ((smtp-user))
+        password: ((smtp-password))
+      from: build-system@example.com
+      to: [ "dev-team@example.com", "product@example.net")) ]
+
+### SUCCESS build notification - Update the email subject and body text below appropriately
+### This operation adds an inline send-email put action to the last job of the pipeline
+- op: add
+  path: /jobs/name=apply-changes/plan/-
+  value:
+    put: send-email
+    params:
+      subject_text: "Build finished successfully: ${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME}/${BUILD_NAME}"
+      body_text: "Build finished successfully: ${ATC_EXTERNAL_URL}/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}"
+
+
+### FAILURE build notifications - Update the email subject and body text below appropriately
+### An `on_failure` even will be added to each job of the pipeline
+- op: add
+  path: /jobs/name=upload-and-stage-tile/on_failure
+  value: &on_failure_object
+    put: send-email
+    params:
+      subject_text: "Build failed: ${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME}/${BUILD_NAME}"
+      body_text: "Build failed: ${ATC_EXTERNAL_URL}/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}"
+
+- op: add
+  path: /jobs/name=regulator/on_failure
+  value:
+    <<: *on_failure_object
+
+- op: add
+  path: /jobs/name=apply-changes/on_failure
+  value:
+    <<: *on_failure_object


### PR DESCRIPTION
A common pipeline customization frequently done by customers is the addition of email notification for pipeline execution success or failures.
The changes in this PR add a sample operations file along with a corresponding link+description for it in the yaml patches samples doc page. 