### PR TITLE
Fix broken ops file

### DIFF
--- a/docs/samples/colocated-credhub-ops/add-credhub-to-atcs.yml
+++ b/docs/samples/colocated-credhub-ops/add-credhub-to-atcs.yml
@@ -228,5 +228,6 @@
 - type: replace
   path: /update/canary_watch_time
   value: 30000-1200000
-- type: /update/update_watch_time
+- type: replace
+  path: /update/update_watch_time
   value: 5000-1200000


### PR DESCRIPTION
I gave you a broken ops file in #253 (sorry about that 😳).

The path is mislabeled as type and the type field is missing.  This fixes it.
