### PR TITLE
clarify gcp/params.yml to leave opsman_client_{id,secret} blank

### DIFF
--- a/install-pcf/gcp/params.yml
+++ b/install-pcf/gcp/params.yml
@@ -158,8 +158,8 @@ networking_poe_ssl_certs:
 # Either opsman_client_id/opsman_client_secret or opsman_admin_username/opsman_admin_password needs to be specified
 opsman_admin_password: CHANGEME
 opsman_admin_username: CHANGEME
-opsman_client_id: CHANGEME
-opsman_client_secret: CHANGEME
+opsman_client_id: # leave blank for initial install
+opsman_client_secret:
 
 # This should be your pcf_ert_domain with "opsman." as a prefix
 opsman_domain_or_ip_address: CHANGEME


### PR DESCRIPTION
* Expected result after the change:
configure-director succeeds and proceeds with user-provider user+pass

* Current result before the change:
configure-director will fail with
```
Configuring IaaS and Director...
configuring iaas specific options for bosh tile
could not execute "configure-bosh": could not fetch form: failed during request: Get https://opsman.cb-pcf.infrastructure.cf-app.com/infrastructure/iaas_configuration/edit: oauth2: cannot fetch token: 401 
Response: {"error":"unauthorized","error_description":"Bad credentials"}
```

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests (I have not, but I suspect this is equivalent to a docs change.)
