### PR TITLE
Updated help in params.yml & errands in bootstrap

### DIFF
--- a/ci/bootstrap/aws/tasks/bootstrap.sh
+++ b/ci/bootstrap/aws/tasks/bootstrap.sh
@@ -85,7 +85,7 @@ ERT_SSL_CERT:
 ERT_SSL_KEY:
 
 mysql_backups: disable
-ert_errands_to_disable: push-apps-manager,notifications,notifications-ui,push-pivotal-account,autoscaling,autoscaling-register-broker,nfsbrokerpush
+ert_errands_to_disable: push-usage-service,push-apps-manager,deploy-notifications,deploy-notifications-ui,push-pivotal-account,deploy-autoscaling,register-broker,nfsbrokerpush
 
 OPSMAN_ALLOW_ACCESS: true
 opsman_allow_cidr: '["0.0.0.0/0"]'

--- a/install-pcf/aws/params.yml
+++ b/install-pcf/aws/params.yml
@@ -82,13 +82,14 @@ apps_domain: CHANGEME   # e.g. apps.pcf.example.com
 #   none
 #   "" (empty string - equivalent to none)
 #   Any combination of the following, separated by comma:
-#     smoke-tests
+#     smoke_tests
+#     push-usage-service
 #     push-apps-manager
-#     notifications
-#     notifications-ui
+#     deploy-notifications
+#     deploy-notifications-ui
 #     push-pivotal-account
-#     autoscaling
-#     autoscaling-register-broker
+#     deploy-autoscaling
+#     register-broker
 #     nfsbrokerpush
 ert_errands_to_disable: none
 

--- a/install-pcf/gcp/params.yml
+++ b/install-pcf/gcp/params.yml
@@ -55,15 +55,16 @@ apps_domain: CHANGEME   # e.g. apps.pcf.example.com
 # Valid values:
 #   all
 #   none
-#   "" (empty string)
+#   "" (empty string - equivalent to none)
 #   Any combination of the following, separated by comma:
-#     smoke-tests
+#     smoke_tests
+#     push-usage-service
 #     push-apps-manager
-#     notifications
-#     notifications-ui
+#     deploy-notifications
+#     deploy-notifications-ui
 #     push-pivotal-account
-#     autoscaling
-#     autoscaling-register-broker
+#     deploy-autoscaling
+#     register-broker
 #     nfsbrokerpush
 ert_errands_to_disable: none
 

--- a/install-pcf/vsphere/params.yml
+++ b/install-pcf/vsphere/params.yml
@@ -101,15 +101,16 @@ enable_vm_resurrector: true
 #   none
 #   "" (empty string - equivalent to none)
 #   Any combination of the following, separated by comma:
-#     smoke-tests
+#     smoke_tests
+#     push-usage-service
 #     push-apps-manager
-#     notifications
-#     notifications-ui
+#     deploy-notifications
+#     deploy-notifications-ui
 #     push-pivotal-account
-#     autoscaling
-#     autoscaling-register-broker
+#     deploy-autoscaling
+#     register-broker
 #     nfsbrokerpush
-ert_errands_to_disable:       # Comma-separated list of errand names to disable before deploy
+ert_errands_to_disable: none
 
 # PCF Elastic Runtime minor version to track
 ert_major_minor_version: 2\.[0-9\]+\.[0-9]+$


### PR DESCRIPTION
Updated the help text/comments in params.yml for the
parameter that determines which errands to run, to reflect
the actual errand names used in PAS 2.0.

Also fixed what errands to disable in bootstrap.sh, so that this
also uses the correct errand names.

Fixes: https://github.com/pivotal-cf/pcf-pipelines/issues/286