### PR TITLE
Ensure that PcfAdminPolicy has ec2:CopyImage permission

### DIFF
--- a/install-pcf/aws/terraform/iam.tf
+++ b/install-pcf/aws/terraform/iam.tf
@@ -139,6 +139,7 @@ data "aws_iam_policy_document" "pcf_iam_rds_role_policy_document" {
                 "ec2:DisassociateAddress",
                 "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeImages",
+                "ec2:CopyImage",
                 "ec2:DescribeInstances",
                 "ec2:RunInstances",
                 "ec2:RebootInstances",


### PR DESCRIPTION
When upgrading from PCF 1.12 to 2.0 we encountered an error when deploying the bosh director

```
creating stemcell (bosh-aws-xen-hvm-ubuntu-trusty-go_agent 3468.21):
  CPI 'create_stemcell' method responded with error: CmdError{"type":"Unknown","message":"You are not authorized to perform this operation.","ok_to_retry":false}
```

Looking at the CloudTrail logs showed this was caused by the `pcf-$FOUNDATION_pcf_iam_user` user lacking the `ec2:CopyImage` IAM permission

I have tested this change in a fork of PCF Pipelines and confirmed that it fixes the error