### PR TITLE
New Set Errand State Task for Tiles

### DIFF
--- a/tasks/config-tile-errand/task.sh
+++ b/tasks/config-tile-errand/task.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e 
+
+if [[ -z "$ERRANDS_TO_TOGGLE" ]] && [[ -z "$ERRANDS_TO_IGNORE" ]]; then
+  echo Nothing to do.
+  exit 0
+else
+  if [[ "$ERRANDS_TO_TOGGLE" == "all" ]] || [[ -z "$ERRANDS_TO_TOGGLE" ]]; then
+    errands=$(
+      om-linux \
+      --target "https://${OPSMAN_DOMAIN_OR_IP_ADDRESS}" \
+      --skip-ssl-validation \
+      --client-id "${OPSMAN_CLIENT_ID}" \
+      --client-secret "${OPSMAN_CLIENT_SECRET}" \
+      --username "$OPSMAN_USERNAME" \
+      --password "$OPSMAN_PASSWORD" \
+      errands \
+      --product-name "$PRODUCT_NAME" |
+      tail -n+3 |
+      awk '{print $2}'
+    )
+    ERRANDS_TO_TOGGLE='["'$(echo $errands | sed 's/ /\"\,\"/g')'"]'
+  fi
+
+  if ! [[ -z "$ERRANDS_TO_IGNORE" ]]; then
+  toggle_errands=($(jq -r -n \
+    --argjson enabled '{ "errands": '$ERRANDS_TO_TOGGLE'}' \
+    --argjson ignore '{ "errands": '$ERRANDS_TO_IGNORE'}' \
+    ' $enabled.errands - $ignore.errands | .[] '))
+  else
+  toggle_errands=($(jq -r -n \
+    --argjson enabled '{ "errands": '$ERRANDS_TO_TOGGLE'}' \
+    '$enabled.errands | .[]'))
+  fi
+  IFS=","
+  for errand in "${toggle_errands[@]}"; do
+    echo "Setting $errand to $ERRAND_STATUS"
+    om-linux \
+      --target "https://${OPSMAN_DOMAIN_OR_IP_ADDRESS}" \
+      --skip-ssl-validation \
+      --client-id "${OPSMAN_CLIENT_ID}" \
+      --client-secret "${OPSMAN_CLIENT_SECRET}" \
+      --username "$OPSMAN_USERNAME" \
+      --password "$OPSMAN_PASSWORD" \
+      set-errand-state \
+      --product-name "$PRODUCT_NAME" \
+      --errand-name $errand \
+      --post-deploy-state $ERRAND_STATUS
+  done
+fi
+

--- a/tasks/config-tile-errand/task.yml
+++ b/tasks/config-tile-errand/task.yml
@@ -19,4 +19,4 @@ params:
   ERRANDS_TO_TOGGLE: # either STRING=all or LIST=[errand_name_1, ..]
   ERRANDS_TO_IGNORE: # LIST=[errand_name_1, ..]; if ERRANDS_TO_IGNORE is set, an empty ERRANDS_TO_TOGGLE defaults to all
 run:
-  path: pcf-pipelines/tasks/activate-cf-errands/task.sh
+  path: pcf-pipelines/tasks/config-tile-errand/task.sh

--- a/tasks/config-tile-errand/task.yml
+++ b/tasks/config-tile-errand/task.yml
@@ -1,0 +1,22 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source: {repository: czero/rootfs}
+
+inputs:
+- name: pcf-pipelines
+
+params:
+  PRODUCT_NAME: 
+  OPSMAN_DOMAIN_OR_IP_ADDRESS: 
+  OPSMAN_CLIENT_ID:  
+  OPSMAN_CLIENT_SECRET:
+  OPSMAN_USERNAME: 
+  OPSMAN_PASSWORD: 
+  ERRAND_STATUS: # enabled|disabled|when-changed
+  ERRANDS_TO_TOGGLE: # either STRING=all or LIST=[errand_name_1, ..]
+  ERRANDS_TO_IGNORE: # LIST=[errand_name_1, ..]; if ERRANDS_TO_IGNORE is set, an empty ERRANDS_TO_TOGGLE defaults to all
+run:
+  path: pcf-pipelines/tasks/activate-cf-errands/task.sh


### PR DESCRIPTION
* A short explanation of the proposed change:
Better Control for errands on tiles than the current tasks. It lets you set the desired state via param, lets you set errands to apply to, lets you explicitly set errands to ignore

* An explanation of the use cases your change solves:
In my case I always wanted to run every errand except the NFSBROKERPUSH for PAS Tile. It would change my resource config (setting File Instance to 1) and additionally would change my FILE STORAGE Settings to Internal webDAV.

* Expected result after the change:
I will not accidentially run the pushnfsbroker errand and change my environment, because i can explicitly declare which errands to config, or exclude and what setting to use.

* Current result before the change:
enable all errands will also enable nfsbrokerpush on opsman 2.0.249 and PAS 2.0.5 and change config for the deployment, not just run the errand

[x] I have viewed signed and have submitted the Contributor License Agreement

[x] I have made this pull request to the `master` branch

[ ] I have run all the unit tests
Nope. 
