### PR TITLE
More strict check for disable-errands task

### DIFF
--- a/tasks/disable-errands/task.sh
+++ b/tasks/disable-errands/task.sh
@@ -34,7 +34,7 @@ will_disable=$(
     --raw-output \
     'split(" ")
     | reduce .[] as $errand ([];
-       if $to_disable | contains($errand) then
+       if $to_disable | split("\n") | index($errand) then
          . + [$errand]
        else
          .


### PR DESCRIPTION
Thanks for contributing to pcf-pipelines. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Currently `disable-errands` task can disable errands which you don't expect it to disable
* An explanation of the use cases your change solves:
Try to disable errands in p-redis tile, e.g.
```
errands_to_disable: "register-broker,on-demand-broker-smoke-tests,upgrade-all-service-instances"
```
`disable-errands` task will also disable `smoke-tests` errand
* Expected result after the change:
```
echo broker-registrar smoke-tests register-broker on-demand-broker-smoke-tests upgrade-all-service-instances broker-deregistrar delete-all-service-instances-and-deregister-broker | jq --arg to_disable 'register-broker
on-demand-broker-smoke-tests
upgrade-all-service-instances' --raw-input --raw-output 'split(" ")
    | reduce .[] as $errand ([];
       if $to_disable | split("\n") | index($errand) then
         . + [$errand]
       else
         .
       end)
    | join("\n")'
register-broker
on-demand-broker-smoke-tests
upgrade-all-service-instances
```
Note: I also tried to use regex for this but I faced issue with jq - https://github.com/stedolan/jq/issues/1629

* Current result before the change:
```
echo broker-registrar smoke-tests register-broker on-demand-broker-smoke-tests upgrade-all-service-instances broker-deregistrar delete-all-service-instances-and-deregister-broker | jq --arg to_disable 'register-broker
on-demand-broker-smoke-tests
upgrade-all-service-instances' --raw-input --raw-output 'split(" ")
    | reduce .[] as $errand ([];
       if $to_disable | contains($errand) then          
         . + [$errand]
       else
         .
       end)
    | join("\n")'
smoke-tests
register-broker
on-demand-broker-smoke-tests
upgrade-all-service-instances
```
* Links to any other associated PRs or issues:

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests 
