### PR TITLE
Gov cloud support

### DIFF
--- a/install-pcf/aws/params.yml
+++ b/install-pcf/aws/params.yml
@@ -13,7 +13,6 @@ aws_alternate_access_key_id: CHANGEME
 aws_alternate_secret_access_key: CHANGEME
 aws_alternate_region: us-gov-west-1
 
-
 aws_az1: us-east-1a
 aws_az2: us-east-1b
 aws_az3: us-east-1d

--- a/install-pcf/aws/params.yml
+++ b/install-pcf/aws/params.yml
@@ -5,6 +5,15 @@ amis_nat: ami-303b1458
 aws_access_key_id: CHANGEME
 aws_secret_access_key: CHANGEME
 
+# For use with GovCloud to support Route53
+# which is not available in GovCloud. These
+# alternate vars would be for the commercial
+# account with Route53.
+aws_alternate_access_key_id: CHANGEME
+aws_alternate_secret_access_key: CHANGEME
+aws_alternate_region: us-gov-west-1
+
+
 aws_az1: us-east-1a
 aws_az2: us-east-1b
 aws_az3: us-east-1d

--- a/install-pcf/aws/pipeline.yml
+++ b/install-pcf/aws/pipeline.yml
@@ -93,11 +93,14 @@ jobs:
       DB_MASTER_PASSWORD: {{db_master_password}}
       TERRAFORM_PREFIX: {{terraform_prefix}}
       aws_access_key_id: {{aws_access_key_id}}
+      aws_alternate_access_key_id: {{aws_alternate_access_key_id}}
       aws_secret_access_key: {{aws_secret_access_key}}
+      aws_alternate_secret_access_key: {{aws_alternate_secret_access_key}}
       aws_key_name: {{aws_key_name}}
       aws_cert_arn: {{aws_cert_arn}}
       amis_nat: {{amis_nat}}
       aws_region: {{aws_region}}
+      aws_alternate_region: {{aws_alternate_region}}
       aws_az1: {{aws_az1}}
       aws_az2: {{aws_az2}}
       aws_az3: {{aws_az3}}

--- a/install-pcf/aws/pipeline.yml
+++ b/install-pcf/aws/pipeline.yml
@@ -390,3 +390,6 @@ jobs:
       AWS_ACCESS_KEY_ID: {{aws_access_key_id}}
       AWS_SECRET_ACCESS_KEY: {{aws_secret_access_key}}
       AWS_REGION: {{aws_region}}
+      AWS_ALTERNATE_ACCESS_KEY_ID: {{aws_alternate_access_key_id}}
+      AWS_ALTERNATE_SECRET_ACCESS_KEY: {{aws_alternate_secret_access_key}}
+      AWS_ALTERNATE_REGION: {{aws_alternate_region}}

--- a/install-pcf/aws/tasks/prepare-aws/task.sh
+++ b/install-pcf/aws/tasks/prepare-aws/task.sh
@@ -31,11 +31,14 @@ terraform plan \
   -var "opsman_allow_https=${OPSMAN_ALLOW_HTTPS}" \
   -var "opsman_allow_https_cidr_ranges=${OPSMAN_ALLOW_HTTPS_CIDR_LIST}" \
   -var "aws_access_key_id=${aws_access_key_id}" \
+  -var "aws_alternate_access_key_id=${aws_alternate_access_key_id}" \
   -var "aws_secret_access_key=${aws_secret_access_key}" \
+  -var "aws_alternate_secret_access_key=${aws_alternate_secret_access_key}" \
   -var "aws_key_name=${aws_key_name}" \
   -var "aws_cert_arn=${aws_cert_arn}" \
   -var "amis_nat=${amis_nat}" \
   -var "aws_region=${aws_region}" \
+  -var "aws_alternate_region=${aws_alternate_region}" \
   -var "aws_az1=${aws_az1}" \
   -var "aws_az2=${aws_az2}" \
   -var "aws_az3=${aws_az3}" \

--- a/install-pcf/aws/tasks/prepare-aws/task.yml
+++ b/install-pcf/aws/tasks/prepare-aws/task.yml
@@ -16,11 +16,14 @@ params:
   DB_MASTER_PASSWORD:
   TERRAFORM_PREFIX:
   aws_access_key_id:
+  aws_alternate_access_key_id:
   aws_secret_access_key:
+  aws_alternate_secret_access_key:
   aws_key_name:
   aws_cert_arn:
   amis_nat:
   aws_region:
+  aws_alternate_region:
   aws_az1:
   aws_az2:
   aws_az3:

--- a/install-pcf/aws/tasks/wipe-env/task.sh
+++ b/install-pcf/aws/tasks/wipe-env/task.sh
@@ -43,8 +43,11 @@ terraform init
 terraform destroy \
   -force \
   -var "aws_access_key_id=${AWS_ACCESS_KEY_ID}" \
+  -var "aws_alternate_access_key_id=${AWS_ALTERNATE_ACCESS_KEY_ID}" \
   -var "aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}" \
+  -var "aws_alternate_secret_access_key=${AWS_ALTERNATE_SECRET_ACCESS_KEY}" \
   -var "aws_region=${AWS_REGION}" \
+  -var "aws_alternate_region=${AWS_ALTERNATE_REGION}" \
   -var "opsman_ami=dontcare" \
   -var "db_master_username=dontcare" \
   -var "db_master_password=dontcare" \

--- a/install-pcf/aws/tasks/wipe-env/task.yml
+++ b/install-pcf/aws/tasks/wipe-env/task.yml
@@ -17,5 +17,8 @@ params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:
   AWS_REGION:
+  AWS_ALTERNATE_ACCESS_KEY_ID:
+  AWS_ALTERNATE_SECRET_ACCESS_KEY:
+  AWS_ALTERNATE_REGION:
 run:
   path: pcf-pipelines/install-pcf/aws/tasks/wipe-env/task.sh

--- a/install-pcf/aws/terraform/aws.tf
+++ b/install-pcf/aws/terraform/aws.tf
@@ -3,3 +3,9 @@ provider "aws" {
     secret_key = "${var.aws_secret_access_key}"
     region = "${var.aws_region}"
 }
+provider "aws" {
+    alias = "alternate"
+    access_key = "${var.aws_alternate_access_key_id}"
+    secret_key = "${var.aws_alternate_secret_access_key}"
+    region = "${var.aws_alternate_region}"
+}

--- a/install-pcf/aws/terraform/iam.tf
+++ b/install-pcf/aws/terraform/iam.tf
@@ -54,14 +54,14 @@ resource "aws_iam_user_policy" "PcfErtPolicy" {
                 "s3:*"
             ],
             "Resource": [
-                "arn:aws:s3:::${var.prefix}-buildpacks",
-                "arn:aws:s3:::${var.prefix}-buildpacks/*",
-                "arn:aws:s3:::${var.prefix}-droplets",
-                "arn:aws:s3:::${var.prefix}-droplets/*",
-                "arn:aws:s3:::${var.prefix}-packages",
-                "arn:aws:s3:::${var.prefix}-packages/*",
-                "arn:aws:s3:::${var.prefix}-resources",
-                "arn:aws:s3:::${var.prefix}-resources/*"
+                "arn:aws-us-gov:s3:::${var.prefix}-buildpacks",
+                "arn:aws-us-gov:s3:::${var.prefix}-buildpacks/*",
+                "arn:aws-us-gov:s3:::${var.prefix}-droplets",
+                "arn:aws-us-gov:s3:::${var.prefix}-droplets/*",
+                "arn:aws-us-gov:s3:::${var.prefix}-packages",
+                "arn:aws-us-gov:s3:::${var.prefix}-packages/*",
+                "arn:aws-us-gov:s3:::${var.prefix}-resources",
+                "arn:aws-us-gov:s3:::${var.prefix}-resources/*"
             ],
             "Effect": "Allow",
             "Sid": "ElasticRuntimeS3Permissions"
@@ -181,8 +181,8 @@ data "aws_iam_policy_document" "pcf_iam_rds_role_policy_document" {
                 "s3:*"
             ],
         resources = [
-                "arn:aws:s3:::${var.prefix}-bosh",
-                "arn:aws:s3:::${var.prefix}-bosh/*",
+                "arn:aws-us-gov:s3:::${var.prefix}-bosh",
+                "arn:aws-us-gov:s3:::${var.prefix}-bosh/*",
         ],
         effect = "Allow",
         sid = "PcfAdminS3Permissions"

--- a/install-pcf/aws/terraform/route53.tf
+++ b/install-pcf/aws/terraform/route53.tf
@@ -1,4 +1,9 @@
+locals {
+  is_alternate = "${var.aws_alternate_region != ""}"
+}
+
 resource "aws_route53_record" "opsman" {
+  count = "${local.is_alternate ? 0 : 1}"
   zone_id = "${var.route53_zone_id}"
   name = "opsman"
   type = "A"
@@ -7,6 +12,7 @@ resource "aws_route53_record" "opsman" {
 }
 
 resource "aws_route53_record" "apps_wild_card" {
+  count = "${local.is_alternate ? 0 : 1}"
   zone_id = "${var.route53_zone_id}"
   name = "*.${element(split(".", var.apps_domain), 0)}"
   type = "CNAME"
@@ -15,6 +21,7 @@ resource "aws_route53_record" "apps_wild_card" {
 }
 
 resource "aws_route53_record" "system_wild_card" {
+  count = "${local.is_alternate ? 0 : 1}"
   zone_id = "${var.route53_zone_id}"
   name = "*.${element(split(".", var.system_domain), 0)}"
   type = "CNAME"
@@ -23,6 +30,47 @@ resource "aws_route53_record" "system_wild_card" {
 }
 
 resource "aws_route53_record" "ssh" {
+  count = "${local.is_alternate ? 0 : 1}"
+  zone_id = "${var.route53_zone_id}"
+  name = "ssh.${element(split(".", var.system_domain), 0)}"
+  type = "CNAME"
+  ttl = "900"
+  records = ["${aws_elb.PcfSshElb.dns_name}"]
+}
+
+resource "aws_route53_record" "opsman_alternate" {
+  count = "${local.is_alternate ? 1 : 0}"
+  provider = "aws.alternate"
+  zone_id = "${var.route53_zone_id}"
+  name = "opsman"
+  type = "A"
+  ttl = "900"
+  records = ["${aws_eip.opsman.public_ip}"]
+}
+
+resource "aws_route53_record" "apps_wild_card_alternate" {
+  count = "${local.is_alternate ? 1 : 0}"
+  provider = "aws.alternate"
+  zone_id = "${var.route53_zone_id}"
+  name = "*.${element(split(".", var.apps_domain), 0)}"
+  type = "CNAME"
+  ttl = "900"
+  records = ["${aws_elb.PcfHttpElb.dns_name}"]
+}
+
+resource "aws_route53_record" "system_wild_card_alternate" {
+  count = "${local.is_alternate ? 1 : 0}"
+  provider = "aws.alternate"
+  zone_id = "${var.route53_zone_id}"
+  name = "*.${element(split(".", var.system_domain), 0)}"
+  type = "CNAME"
+  ttl = "900"
+  records = ["${aws_elb.PcfHttpElb.dns_name}"]
+}
+
+resource "aws_route53_record" "ssh_alternate" {
+  count = "${local.is_alternate ? 1 : 0}"
+  provider = "aws.alternate"
   zone_id = "${var.route53_zone_id}"
   name = "ssh.${element(split(".", var.system_domain), 0)}"
   type = "CNAME"

--- a/install-pcf/aws/terraform/variables.tf
+++ b/install-pcf/aws/terraform/variables.tf
@@ -1,5 +1,7 @@
 variable "aws_access_key_id" {}
+variable "aws_alternate_access_key_id" {}
 variable "aws_secret_access_key" {}
+variable "aws_alternate_secret_access_key" {}
 variable "aws_key_name" {}
 variable "aws_cert_arn" {}
 variable "db_master_username" {}
@@ -8,6 +10,7 @@ variable "prefix" {}
 variable "opsman_ami" {}
 variable "amis_nat" {}
 variable "aws_region" {}
+variable "aws_alternate_region" {}
 variable "aws_az1" {}
 variable "aws_az2" {}
 variable "aws_az3" {}


### PR DESCRIPTION
Thanks for contributing to pcf-pipelines. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Due to the fact gov cloud does not have route53. We have modified the pipeline to support a commercial AWS route 53 by using two providers conditionally 

* An explanation of the use cases your change solves:
Gov cloud not having route53

* Expected result after the change:
Backward compatibility but allows gov cloud to deploy along side with commercial AWS route53 

* Current result before the change:
PCF pipelines fail with gov cloud due to gov cloud not having route53

* Links to any other associated PRs or issues:

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests 
