### PR TITLE
Comment changes for params.yml

### DIFF
--- a/install-pcf/gcp/params.yml
+++ b/install-pcf/gcp/params.yml
@@ -47,9 +47,12 @@ db_uaa_password: CHANGEME
 db_uaa_username: CHANGEME
 
 # Domain Names for ERT
-pcf_ert_domain: CHANGEME # This is the domain you will access ERT with, for example: pcf.example.com.
-system_domain: CHANGEME # e.g. system.pcf.example.com
-apps_domain: CHANGEME   # e.g. apps.pcf.example.com
+# This is the domain you will access ERT with, for example: pcf.example.com.  A hosted zone will be created for this domain.
+pcf_ert_domain: CHANGEME
+# e.g. system.pcf.example.com, this needs to be a subdomain of pcf_ert_domain
+system_domain: CHANGEME
+# e.g. apps.pcf.example.com, this needs to be a subdomain of pcf_ert_domain
+apps_domain: CHANGEME   
 
 # Errands to disable prior to deploying ERT
 # Valid values:

--- a/install-pcf/gcp/params.yml
+++ b/install-pcf/gcp/params.yml
@@ -99,7 +99,7 @@ gcp_zone_1: us-central1-a
 gcp_zone_2: us-central1-b
 gcp_zone_3: us-central1-c
 
-# Optional - if your git repo requires an SSH key. You will need to comment out line 99 if you do not use the git_private_key.
+# Optional - if your git repo requires an SSH key.
 git_private_key:
 
 # Required if haproxy_forward_tls is enabled - HAProxy will use the CA provided to verify the certificates provided by the router.


### PR DESCRIPTION
Some comment improvements for params.yml:

- Remove comment with a bad line number reference
- Add clarity to the domains section to reduce future errors

Thanks for contributing to pcf-pipelines. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Comment only changes/enhancements

* An explanation of the use cases your change solves:
Less confusing for first time users. I misunderstood how the domains worked and it cost me some time, hopefully this will save sometime angst in the future.

* Expected result after the change:
comment only

* Current result before the change:
comment only

* Links to any other associated PRs or issues:
n/a

* [ X] I have viewed signed and have submitted the Contributor License Agreement 
I work for Pivotal and am public and therefore I should not need to sign it.

* [X ] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests 
comment only, but I have been deploying it/using it as a part of setting up a PCF environment
