### PR TITLE
Allow the database type used by PAS to be either internel or external

### DIFF
--- a/install-pcf/aws/params.yml
+++ b/install-pcf/aws/params.yml
@@ -193,3 +193,6 @@ container_networking_nw_cidr: 10.255.0.0/16 # C2C Networking network CIDR
 
 # Whether or not the ERT VMs are internet connected.
 internet_connected: false
+
+ert_database_type: external
+

--- a/install-pcf/aws/pipeline.yml
+++ b/install-pcf/aws/pipeline.yml
@@ -125,6 +125,7 @@ jobs:
       nat_ip_az3: {{nat_ip_az3}}
       OPSMAN_ALLOW_SSH_CIDR_RANGES: {{opsman_allow_ssh_cidr_ranges}}
       OPSMAN_ALLOW_HTTPS_CIDR_RANGES: {{opsman_allow_https_cidr_ranges}}
+      ert_database_type: {{ert_database_type}}
     ensure:
       put: terraform-state
       params:
@@ -159,6 +160,7 @@ jobs:
       DB_LOCKET_PASSWORD: {{db_locket_password}}
       DB_SILK_USERNAME: {{db_silk_username}}
       DB_SILK_PASSWORD: {{db_silk_password}}
+      ERT_DATABASE_TYPE: {{ert_database_type}}
 
 - name: configure-director
   serial_groups: [opsman]
@@ -335,6 +337,7 @@ jobs:
       azure_droplets_container:
       azure_packages_container:
       azure_resources_container:
+      ert_database_type: {{ert_database_type}}
 
   - task: disable-errands
     file: pcf-pipelines/tasks/disable-errands/task.yml

--- a/install-pcf/aws/tasks/config-director/task.sh
+++ b/install-pcf/aws/tasks/config-director/task.sh
@@ -4,7 +4,9 @@ set -eu
 
 aws_access_key_id=`terraform state show -state terraform-state/terraform.tfstate aws_iam_access_key.pcf_iam_user_access_key | grep ^id | awk '{print $3}'`
 aws_secret_access_key=`terraform state show -state terraform-state/terraform.tfstate aws_iam_access_key.pcf_iam_user_access_key | grep ^secret | awk '{print $3}'`
-rds_password=`terraform state show -state terraform-state/terraform.tfstate aws_db_instance.pcf_rds | grep ^password | awk '{print $3}'`
+if [ ${ert_database_type} != "internal" ]; then
+    rds_password=`terraform state show -state terraform-state/terraform.tfstate aws_db_instance.pcf_rds | grep ^password | awk '{print $3}'`
+fi
 
 while read -r line
 do
@@ -26,30 +28,50 @@ read -r -d '' iaas_configuration <<EOF
 }
 EOF
 
-read -r -d '' director_configuration <<EOF
-{
-  "ntp_servers_string": "0.amazon.pool.ntp.org,1.amazon.pool.ntp.org,2.amazon.pool.ntp.org,3.amazon.pool.ntp.org",
-  "resurrector_enabled": true,
-  "max_threads": 30,
-  "database_type": "external",
-  "external_database_options": {
-    "host": "$db_host",
-    "port": 3306,
-    "user": "$db_username",
-    "password": "$rds_password",
-    "database": "$db_database"
-  },
-  "blobstore_type": "s3",
-  "s3_blobstore_options": {
-    "endpoint": "$S3_ENDPOINT",
-    "bucket_name": "$s3_pcf_bosh",
-    "access_key": "$aws_access_key_id",
-    "secret_key": "$aws_secret_access_key",
-    "signature_version": "4",
-    "region": "$AWS_REGION"
-  }
-}
+if [ ${ert_database_type} != "internal" ]; then
+    read -r -d '' director_configuration <<EOF
+    {
+      "ntp_servers_string": "0.amazon.pool.ntp.org,1.amazon.pool.ntp.org,2.amazon.pool.ntp.org,3.amazon.pool.ntp.org",
+      "resurrector_enabled": true,
+      "max_threads": 30,
+      "database_type": "external",
+      "external_database_options": {
+        "host": "$db_host",
+        "port": 3306,
+        "user": "$db_username",
+        "password": "$rds_password",
+        "database": "$db_database"
+      },
+      "blobstore_type": "s3",
+      "s3_blobstore_options": {
+        "endpoint": "$S3_ENDPOINT",
+        "bucket_name": "$s3_pcf_bosh",
+        "access_key": "$aws_access_key_id",
+        "secret_key": "$aws_secret_access_key",
+        "signature_version": "4",
+        "region": "$AWS_REGION"
+      }
+    }
 EOF
+else
+    read -r -d '' director_configuration <<EOF
+    {
+      "ntp_servers_string": "0.amazon.pool.ntp.org,1.amazon.pool.ntp.org,2.amazon.pool.ntp.org,3.amazon.pool.ntp.org",
+      "resurrector_enabled": true,
+      "max_threads": 30,
+      "database_type": "internal",
+      "blobstore_type": "s3",
+      "s3_blobstore_options": {
+        "endpoint": "$S3_ENDPOINT",
+        "bucket_name": "$s3_pcf_bosh",
+        "access_key": "$aws_access_key_id",
+        "secret_key": "$aws_secret_access_key",
+        "signature_version": "4",
+        "region": "$AWS_REGION"
+      }
+    }
+EOF
+fi
 
 resource_configuration=$(cat <<-EOF
 {

--- a/install-pcf/aws/tasks/config-director/task.yml
+++ b/install-pcf/aws/tasks/config-director/task.yml
@@ -29,5 +29,6 @@ params:
   dynamic_services_subnet_reserved_ranges_z2:
   dynamic_services_subnet_reserved_ranges_z3:
   infra_subnet_reserved_ranges_z1:
+  ert_database_type:
 run:
   path: pcf-pipelines/install-pcf/aws/tasks/config-director/task.sh

--- a/install-pcf/aws/tasks/prepare-aws/task.sh
+++ b/install-pcf/aws/tasks/prepare-aws/task.sh
@@ -61,6 +61,7 @@ terraform plan \
   -var "nat_ip_az1=${nat_ip_az1}" \
   -var "nat_ip_az2=${nat_ip_az2}" \
   -var "nat_ip_az3=${nat_ip_az3}" \
+  -var "rds_count=${rds_count}" \
   -out terraform.tfplan \
   pcf-pipelines/install-pcf/aws/terraform
 

--- a/install-pcf/aws/tasks/prepare-aws/task.yml
+++ b/install-pcf/aws/tasks/prepare-aws/task.yml
@@ -48,5 +48,6 @@ params:
   nat_ip_az3:
   OPSMAN_ALLOW_SSH_CIDR_RANGES:
   OPSMAN_ALLOW_HTTPS_CIDR_RANGES:
+  ert_database_type:
 run:
   path: pcf-pipelines/install-pcf/aws/tasks/prepare-aws/task.sh

--- a/install-pcf/aws/tasks/prepare-rds/task.sh
+++ b/install-pcf/aws/tasks/prepare-rds/task.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -eu
 
+if [ ${ERT_DATABASE_TYPE} = "internal" ]; then
+    exit 0
+fi
+
 echo "$PEM" > pcf.pem
 chmod 0600 pcf.pem
 

--- a/install-pcf/aws/tasks/prepare-rds/task.yml
+++ b/install-pcf/aws/tasks/prepare-rds/task.yml
@@ -35,5 +35,6 @@ params:
   DB_LOCKET_PASSWORD:
   DB_SILK_USERNAME:
   DB_SILK_PASSWORD:
+  ERT_DATABASE_TYPE:
 run:
   path: pcf-pipelines/install-pcf/aws/tasks/prepare-rds/task.sh

--- a/install-pcf/aws/terraform/outputs.tf
+++ b/install-pcf/aws/terraform/outputs.tf
@@ -202,17 +202,17 @@ output "dynamic_services_subnet_id_az3" {
 # RDS info
 
 output "db_host" {
-    value = "${aws_db_instance.pcf_rds.address}"
+    value = "${element(concat(aws_db_instance.pcf_rds.*.address, list("")), 0)}"
 }
 output "db_port" {
-    value = "${aws_db_instance.pcf_rds.port}"
+    value = "${element(concat(aws_db_instance.pcf_rds.*.port, list("")), 0)}"
 }
 output "db_username" {
-    value = "${aws_db_instance.pcf_rds.username}"
+    value = "${element(concat(aws_db_instance.pcf_rds.*.username, list("")), 0)}"
 }
 output "db_password" {
-    value = "${aws_db_instance.pcf_rds.password}"
+    value = "${element(concat(aws_db_instance.pcf_rds.*.password, list("")), 0)}"
 }
 output "db_database" {
-    value = "${aws_db_instance.pcf_rds.name}"
+    value = "${element(concat(aws_db_instance.pcf_rds.*.name, list("")), 0)}"
 }

--- a/install-pcf/aws/terraform/rds.tf
+++ b/install-pcf/aws/terraform/rds.tf
@@ -1,4 +1,5 @@
 resource "aws_db_subnet_group" "rds_subnet_group" {
+    count = "${var.rds_count}"
     name = "${var.prefix}-rds_subnet_group"
     subnet_ids = ["${aws_subnet.PcfVpcRdsSubnet_az1.id}", "${aws_subnet.PcfVpcRdsSubnet_az2.id}", "${aws_subnet.PcfVpcRdsSubnet_az3.id}"]
     tags {
@@ -6,6 +7,7 @@ resource "aws_db_subnet_group" "rds_subnet_group" {
     }
 }
 resource "aws_db_instance" "pcf_rds" {
+    count                   = "${var.rds_count}"
     identifier              = "${var.prefix}-pcf"
     allocated_storage       = 100
     engine                  = "mariadb"

--- a/install-pcf/aws/terraform/variables.tf
+++ b/install-pcf/aws/terraform/variables.tf
@@ -152,3 +152,8 @@ variable "nat_ip_az3" {
     default = "10.0.2.6"
 }
 
+
+variable "rds_count" {
+    description = "Create a RDS instance"
+    default = 1
+}

--- a/tasks/configure-ert/task.yml
+++ b/tasks/configure-ert/task.yml
@@ -88,3 +88,4 @@ params:
   db_silk_password:
   routing_disable_http:
   SECURITY_ACKNOWLEDGEMENT:
+  ert_database_type:


### PR DESCRIPTION
Thanks for contributing to pcf-pipelines. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Make the PAS database type configurable. 

* An explanation of the use cases your change solves:
pcf-pipelines is hard coded to use the external database only. Some environments use the internal database. This PR makes the database type configurable for either external (default) or internal.

* Expected result after the change:
Allows the user to use the internal database if they so chose. If the user makes no change, defaults to current selection of external.

* Current result before the change:
Unable to use internal database.

* Links to any other associated PRs or issues:

* [X ] I have viewed signed and have submitted the Contributor License Agreement

* [X ] I have made this pull request to the `master` branch

* [X ] I have run all the unit tests 
