### PR TITLE
Update create-infrastructure task to use OS_CACERT

### DIFF
--- a/install-pcf/openstack/tasks/create-infrastructure/task.sh
+++ b/install-pcf/openstack/tasks/create-infrastructure/task.sh
@@ -4,6 +4,9 @@ set -eu
 
 ROOT=$PWD
 
+echo "$OPENSTACK_CA_CERT" > /ca.crt
+export OS_CACERT='/ca.crt'
+
 function get_opsman_version() {
   cut -d\# -f 1 ops-manager/version
 }

--- a/install-pcf/openstack/tasks/create-infrastructure/task.yml
+++ b/install-pcf/openstack/tasks/create-infrastructure/task.yml
@@ -35,6 +35,7 @@ params:
   DYNAMIC_SERVICES_DNS:
   EXTERNAL_NETWORK:
   EXTERNAL_NETWORK_ID:
+  OPENSTACK_CA_CERT:
 
 run:
   path: pcf-pipelines/install-pcf/openstack/tasks/create-infrastructure/task.sh


### PR DESCRIPTION
Thanks for contributing to pcf-pipelines. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Add a couple lines to the task.sh file to allow terraform to talk to the openstack API with self-signed certs

* An explanation of the use cases your change solves:
This solves the use case where the create-infrastructure step fails when the openstack API cert is signed with an internal CA or is self-signed

* Expected result after the change:
Terraform init/plan/apply will not fail with "x509 unknown certificate" when the openstack API is secured with a self-signed (or internal CA signed) certificate

* Current result before the change:
Terraform commands fail with "x509 unknown certificate" when the openstack API cert is self-signed (or signed with an internal CA)

* Links to any other associated PRs or issues:
This is present already in the other openstack tasks via API_SSL_CERT or OPENSTACK_CA_CERT, but doesn't seem to be present in the create-infrastructure task

I ran the test suite and returned the following results:
Ran 312 of 312 Specs in 0.108 seconds
FAIL! -- 306 Passed | 6 Failed | 0 Pending | 0 Skipped

The 6 that failed involve the upgrade-buildpacks pipeline and pcf-pipelines pipeline, not the openstack create-infrastructure task

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests 
