### PR TITLE
Update Credhub ops file to accomodate latest versions

### DIFF
--- a/docs/samples/colocated-credhub-ops/README.md
+++ b/docs/samples/colocated-credhub-ops/README.md
@@ -14,18 +14,38 @@ UAA, and load CredHub with secrets prior to disabling the Vault integration.
 
 ## Usage
 
-Upload the [CredHub](http://bosh.io/releases/github.com/pivotal-cf/credhub-release?all=1)
-and [UAA](http://bosh.io/releases/github.com/cloudfoundry/uaa-release?all=1) releases
-to your BOSH director.
+These ops files were written with [`concourse-bosh-deployment`](https://github.com/concourse/concourse-bosh-deployment)
+in mind.
 
 Then simply define the required variables and apply the operations files with `-o <file>`
 as part of the `bosh deploy` command (CLI v2 only).  Variables can be defined in a YAML
 file along with the `-l` flag, or specified inline on the command line with `-v VAR=VALUE`.
 
-You may also use `bosh int` to view the interpolated manifest:
+For example, your command may look something like the following.
+
+Note: this is a representative example, you will want to consult the
+full gamut of operations files provided by `concourse-bosh-deployment`
+to determine which options are suitable for your deployment.
 
 ```
-$ bosh int concourse.yml -o add-credhub-to-atc.yml -o replace-vault-with-credhub.yml
+$ bosh deploy -d concourse ~/concourse-bosh-deployment/cluster/concourse.yml \
+   -l ~/concourse-bosh-deployment/versions.yml \
+   -o concourse-bosh-deployment/cluster/operations/tls.yml \
+   -o concourse-bosh-deployment/cluster/operations/tls-vars.yml \
+   -o add-credhub-to-atcs.yml \
+   -o replace-vault-with-credhub.yml \
+   -v deployment_name=concourse \
+   -v network_name=default \
+   -v worker_vm_type=medium \
+   -v web_vm_type=medium \
+   -v db_vm_type=medium \
+   -v uaa_release_version=60 \
+   -v uaa_sha=a7c14357ae484e89e547f4f207fb8de36d2b0966 \
+   -v credhub_release_version=1.9.3 \
+   -v credhub_sha=648658efdef2ff18a69914d958bcd7ebfa88027a \
+   -v db_persistent_disk_type=100GB \
+   -v external_url=http://concourse.example.com \
+   -v external_hostname=concourse.example.com
 ```
 
 **Note:** CredHub integration requires Concourse 3.5.0 or later.

--- a/docs/samples/colocated-credhub-ops/add-credhub-to-atcs.yml
+++ b/docs/samples/colocated-credhub-ops/add-credhub-to-atcs.yml
@@ -1,4 +1,4 @@
-# add missing variables
+# Add new variables so that BOSH can generate them for us.
 - type: replace
   path: /variables?/name=atc-db-password?
   value:
@@ -11,24 +11,6 @@
     type: password
     options:
       length: 40
-- type: replace
-  path: /variables?/name=concourse-ca?
-  value:
-    name: concourse-ca
-    type: certificate
-    options:
-      is_ca: true
-      common_name: Concourse CA
-- type: replace
-  path: /variables?/name=concourse-tls?
-  value:
-    name: concourse-tls
-    type: certificate
-    options:
-      ca: concourse-ca
-      common_name: {{concourse_host}}
-      alternative_names:
-      - {{concourse_host}}
 - type: replace
   path: /variables?/name=credhub-db-password?
   value:
@@ -87,22 +69,28 @@
     name: concourse_client_secret
     type: password
 - type: replace
-  path: /variables?/name=main-team-password?
+  path: /variables?/name=encryption-keys-passphrase
   value:
-    name: main-team-password
+    name: encryption-keys-passphrase
     type: password
+    options:
+      length: 40
 
 # add UAA and credhub releases
 - type: replace
   path: /releases/-
   value:
     name: uaa
-    version: latest
+    version: ((uaa_release_version))
+    sha1: ((uaa_sha))
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=((uaa_release_version))
 - type: replace
   path: /releases/-
   value:
     name: credhub
-    version: latest
+    version: ((credhub_release_version))
+    sha1: ((credhub_sha))
+    url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=((credhub_release_version))
 
 # update DB instance to include credhub and uaa databases
 - type: replace
@@ -117,61 +105,33 @@
   path: /instance_groups/name=db/jobs/name=postgres/properties/databases/roles/-
   value:
     name: credhub
-    password: {{credhub-db-password}}
+    password: ((credhub-db-password))
 - type: replace
   path: /instance_groups/name=db/jobs/name=postgres/properties/databases/roles/-
   value:
     name: uaa
-    password: {{uaa-db-password}}
+    password: ((uaa-db-password))
 
-# add credhub job to ATC instance group
-- type: replace
-  path: /instance_groups/name=web/jobs/-
-  value:
-    name: credhub
-    release: credhub
-    properties:
-      credhub:
-        port: 8844
-        authentication:
-          uaa:
-            url: *uaa-url
-            verification_key: ((uaa-jwt.public_key))
-            ca_certs:
-            - ((concourse-tls.ca))
-        data_storage:
-          type: postgres
-          host: {{db_ip}}
-          port: 5432
-          username: credhub
-          password: {{credhub-db-password}}
-          database: credhub
-          require_tls: false
-        tls: {{concourse-tls}}
-        log_level: info
-        encryption:
-          keys:
-          - provider_name: int
-            encryption_password: {{credhub-encryption-password}}
-            active: true
-          providers:
-          - name: int
-            type: internal
-
-# add UAA job to ATC instance group
+# add UAA job to web instance group
 - type: replace
   path: /instance_groups/name=web/jobs/-
   value:
     name: uaa
     release: uaa
     properties:
+      encryption:
+        encryption_keys:
+        - label: 'KEY-1'
+          passphrase: ((encryption-keys-passphrase))
+        active_key_label: 'KEY-1'
       uaa:
-        url: &uaa-url "https://((concourse_host)):8443"
-        port: -1
+        url: &uaa-url ((external_url)):8443
+        port: 8181
+        logging_level: INFO
         scim:
           users:
           - name: admin
-            password: {{uaa-users-admin}}
+            password: ((uaa-users-admin))
             groups:
             - scim.write
             - scim.read
@@ -192,14 +152,14 @@
             authorized-grant-types: client_credentials
             scope: ""
             authorities: credhub.read,credhub.write
-            access-token-validity: 30
+            access-token-validity: 1200
             refresh-token-validity: 3600
-            secret: {{concourse_to_credhub_secret}}
-        admin: {client_secret: {{uaa-admin}}}
-        login: {client_secret: {{uaa-login}}}
+            secret: ((concourse_to_credhub_secret))
+        admin: {client_secret: ((uaa-admin))}
+        login: {client_secret: ((uaa-login))}
         zones: {internal: {hostnames: []}}
-        sslCertificate: ((concourse-tls.certificate))
-        sslPrivateKey: ((concourse-tls.private_key))
+        sslCertificate: ((atc_tls.certificate))
+        sslPrivateKey: ((atc_tls.private_key))
         jwt:
           revocable: true
           policy:
@@ -208,8 +168,6 @@
               key-1:
                 signingKey: ((uaa-jwt.private_key))
       uaadb:
-        address: {{db_ip}}
-        port: 5432
         db_scheme: postgresql
         databases:
         - tag: uaa
@@ -217,12 +175,44 @@
         roles:
         - tag: admin
           name: uaa
-          password: {{uaa-db-password}}
+          password: ((uaa-db-password))
       login:
         saml:
-          serviceProviderCertificate: ((concourse-tls.certificate))
-          serviceProviderKey: ((concourse-tls.private_key))
+          serviceProviderCertificate: ((atc_tls.certificate))
+          serviceProviderKey: ((atc_tls.private_key))
           serviceProviderKeyPassword: ""
+
+# add credhub job to web instance group
+- type: replace
+  path: /instance_groups/name=web/jobs/-
+  value:
+    name: credhub
+    release: credhub
+    properties:
+      credhub:
+        port: 8844
+        authentication:
+          uaa:
+            url: *uaa-url
+            verification_key: ((uaa-jwt.public_key))
+            ca_certs:
+            - ((atc_tls.ca))
+        data_storage:
+          type: postgres
+          username: credhub
+          password: ((credhub-db-password))
+          database: credhub
+          require_tls: false
+        tls: ((atc_tls))
+        log_level: debug
+        encryption:
+          keys:
+          - provider_name: int
+            encryption_password: ((credhub-encryption-password))
+            active: true
+          providers:
+          - name: int
+            type: internal
 
 # modify update settings to give UAA enough time to start up
 - type: replace

--- a/docs/samples/colocated-credhub-ops/replace-vault-with-credhub.yml
+++ b/docs/samples/colocated-credhub-ops/replace-vault-with-credhub.yml
@@ -1,14 +1,14 @@
 # remove existing vault configuration
 - type: remove
-  path: /instance_groups/name=web/jobs/name=atc/properties/vault
+  path: /instance_groups/name=web/jobs/name=atc/properties/vault?
 
-# add credhub configuration
+# Configure Concourse to use credhub
 - type: replace
   path: /instance_groups/name=web/jobs/name=atc/properties/credhub?
   value:
-    url: https://((concourse_host)):8844
+    url: ((external_url)):8844
     tls:
-      ca_cert: {{concourse-ca}}
-      insecure_skip_verify: {{credhub_insecure_skip_verify}}
+      ca_cert:
+        certificate: ((atc_tls.ca))
     client_id: concourse_to_credhub
-    client_secret: {{concourse_to_credhub_secret}}
+    client_secret: ((concourse_to_credhub_secret))


### PR DESCRIPTION
Updates the reference operations file and documentation to help users understand how to deploy and integrate Credhub in their Concourse environment.

The existing versions of this documentation was out of date and didn't work with the latest versions of Concourse and Credhub.