### PR TITLE
Enable SQL backups in GCP by default

### DIFF
--- a/install-pcf/gcp/terraform/sql.tf
+++ b/install-pcf/gcp/terraform/sql.tf
@@ -10,6 +10,11 @@ resource "google_sql_database_instance" "master" {
   settings {
     tier = "${var.db_cloudsqldb_tier}"
 
+    backup_configuration = {
+      binary_log_enabled = true
+      enabled = true
+    }
+
     ip_configuration = {
       ipv4_enabled = true
 


### PR DESCRIPTION
Thanks for submitting an pull request to pcf-pipelines.

To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Backup GCP SQL databases by default.

* An explanation of the use cases your change solves:

bbr docs explicitly call out that external DBs are not backed up, leaving a GCP deployment with no database backups until this is enabled or done manually.

* Expected result after the change:

databases are backed up,

* Current result before the change:

databases are not backed up

* Links to any other associated PRs or issues:

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests 
