### PR TITLE
increase LB timeout for bind operation on GCP

### DIFF
--- a/install-pcf/gcp/terraform/loadbalancing_http.tf
+++ b/install-pcf/gcp/terraform/loadbalancing_http.tf
@@ -14,7 +14,7 @@ resource "google_compute_backend_service" "ert_http_lb_backend_service" {
   name        = "${var.prefix}-http-lb-backend"
   port_name   = "http"
   protocol    = "HTTP"
-  timeout_sec = 30
+  timeout_sec = 60
   enable_cdn  = false
 
   backend {


### PR DESCRIPTION
Thanks for submitting an pull request to pcf-pipelines.

To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Increase Load balancer timeout from 30 -> 60 seconds to support bind operation on GCP

* An explanation of the use cases your change solves:
Able to bind service which requires backend calls for provisioning credentials on data services

* Expected result after the change:
Able to bind cloud sql service on gcp

* Current result before the change:
Timeout error from Loadbalancer

* Links to any other associated PRs or issues:
https://github.com/GoogleCloudPlatform/gcp-service-broker/issues/199

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests 
