### PR TITLE
Optional failure for a tile that is already staged

### DIFF
--- a/ci/pcf-pipelines/pipeline.yml
+++ b/ci/pcf-pipelines/pipeline.yml
@@ -193,7 +193,11 @@ resources:
   type: pool
   source:
     pool: vsphere
-    <<: *norm-ci-locks-params
+    <<: &norm-ci-locks-params
+      uri: git@github.com:pivotal-cf/norm-ci-locks.git
+      branch: master
+      private_key: {{locks_git_ssh_key}}
+      retry_delay: 1m
 
 - name: vsphere-offline-lock
   type: pool
@@ -312,7 +316,10 @@ jobs:
 
 - name: test
   on_failure:
-    <<: *notify_slack
+    <<: &notify_slack
+      put: slack
+      params:
+        text: "$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME failed: $ATC_EXTERNAL_URL/builds/$BUILD_ID"
   plan:
   - get: pcf-pipelines
     trigger: true
@@ -428,7 +435,11 @@ jobs:
   - task: destroy-rc-vsphere-install
     params:
       PIPELINE_NAME: rc-vsphere-install
-      <<: *vsphere_atc_creds
+      <<: &vsphere_atc_creds
+        ATC_EXTERNAL_URL: {{atc_external_url}}
+        ATC_BASIC_AUTH_USERNAME: {{fly_basic_auth_username}}
+        ATC_BASIC_AUTH_PASSWORD: {{fly_basic_auth_password}}
+        ATC_TEAM_NAME: vsphere
     file: pcf-pipelines/ci/tasks/destroy_pipeline.yml
 
 - name: set-rc-vsphere-install
@@ -560,7 +571,11 @@ jobs:
   - task: destroy-rc-gcp-install
     params:
       PIPELINE_NAME: rc-gcp-install
-      <<: *atc_creds
+      <<: &atc_creds
+        ATC_EXTERNAL_URL: {{atc_external_url}}
+        ATC_BASIC_AUTH_USERNAME: {{fly_basic_auth_username}}
+        ATC_BASIC_AUTH_PASSWORD: {{fly_basic_auth_password}}
+        ATC_TEAM_NAME: {{atc_team_name}}
     file: pcf-pipelines/ci/tasks/destroy_pipeline.yml
 
 - name: set-rc-gcp-install
@@ -1453,26 +1468,3 @@ jobs:
   on_failure:
     <<: *notify_slack
 ####### END VSPHERE OFFLINE
-
-atc_creds: &atc_creds
-  ATC_EXTERNAL_URL: {{atc_external_url}}
-  ATC_BASIC_AUTH_USERNAME: {{fly_basic_auth_username}}
-  ATC_BASIC_AUTH_PASSWORD: {{fly_basic_auth_password}}
-  ATC_TEAM_NAME: {{atc_team_name}}
-
-vsphere_atc_creds: &vsphere_atc_creds
-  ATC_EXTERNAL_URL: {{atc_external_url}}
-  ATC_BASIC_AUTH_USERNAME: {{fly_basic_auth_username}}
-  ATC_BASIC_AUTH_PASSWORD: {{fly_basic_auth_password}}
-  ATC_TEAM_NAME: vsphere
-
-notify_slack: &notify_slack
-  put: slack
-  params:
-    text: "$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME failed: $ATC_EXTERNAL_URL/builds/$BUILD_ID"
-
-norm-ci-locks-params: &norm-ci-locks-params
-  uri: git@github.com:pivotal-cf/norm-ci-locks.git
-  branch: master
-  private_key: {{locks_git_ssh_key}}
-  retry_delay: 1m

--- a/install-pcf/aws/pipeline.yml
+++ b/install-pcf/aws/pipeline.yml
@@ -249,6 +249,7 @@ jobs:
       OPSMAN_CLIENT_SECRET: ""
       OPSMAN_USERNAME: {{opsman_admin_username}}
       OPSMAN_PASSWORD: {{opsman_admin_password}}
+      SKIP_IF_ALREADY_STAGED: no
 
 - name: deploy-ert
   serial_groups: [opsman]

--- a/install-pcf/azure/pipeline.yml
+++ b/install-pcf/azure/pipeline.yml
@@ -345,6 +345,7 @@ jobs:
       OPSMAN_CLIENT_SECRET: ""
       OPSMAN_USERNAME: {{opsman_admin_username}}
       OPSMAN_PASSWORD: {{opsman_admin_password}}
+      SKIP_IF_ALREADY_STAGED: no
 
 ###########################
 ## Job - Configure ERT   ##

--- a/install-pcf/gcp/pipeline.yml
+++ b/install-pcf/gcp/pipeline.yml
@@ -238,6 +238,7 @@ jobs:
       OPSMAN_PASSWORD: {{opsman_admin_password}}
       OPSMAN_CLIENT_ID: ""
       OPSMAN_CLIENT_SECRET: ""
+      SKIP_IF_ALREADY_STAGED: no
 
 
 - name: deploy-ert

--- a/install-pcf/openstack/pipeline.yml
+++ b/install-pcf/openstack/pipeline.yml
@@ -271,6 +271,7 @@ jobs:
       OPSMAN_PASSWORD: {{opsman_admin_password}}
       OPSMAN_CLIENT_ID: ""
       OPSMAN_CLIENT_SECRET: ""
+      SKIP_IF_ALREADY_STAGED: no
 
 
 - name: configure-ert

--- a/install-pcf/vsphere/pipeline.yml
+++ b/install-pcf/vsphere/pipeline.yml
@@ -210,6 +210,7 @@ jobs:
       OPSMAN_PASSWORD: {{opsman_admin_password}}
       OPSMAN_CLIENT_ID: ""
       OPSMAN_CLIENT_SECRET: ""
+      SKIP_IF_ALREADY_STAGED: no
 
 
 - name: deploy-ert

--- a/tasks/stage-product/task.sh
+++ b/tasks/stage-product/task.sh
@@ -51,10 +51,15 @@ UNSTAGED_PRODUCT=$(echo "$UNSTAGED_ALL" | jq \
 )
 
 # There should be only one such unstaged product.
-if [ "$(echo $UNSTAGED_PRODUCT | jq '. | length')" -ne "1" ]; then
-  echo "Need exactly one unstaged build for $PRODUCT_NAME version $desired_version"
+if [[ "$(echo $UNSTAGED_PRODUCT | jq '. | length')" -ne "1" ]]; then
+  echo "Need exactly one unstaged build for staging $PRODUCT_NAME version $desired_version"
   jq -n "$UNSTAGED_PRODUCT"
-  exit 1
+  if echo "$SKIP_IF_ALREADY_STAGED" | egrep -iq '(true|yes|y|t|1)' ; then
+    echo "Skipping staging for $PRODUCT_NAME version $desired_version"
+    exit 0
+  else
+    exit 1
+  fi
 fi
 
 full_version=$(echo "$UNSTAGED_PRODUCT" | jq -r '.[].product_version')

--- a/tasks/stage-product/task.yml
+++ b/tasks/stage-product/task.yml
@@ -31,6 +31,7 @@ params:
   OPSMAN_USERNAME:
   OPSMAN_PASSWORD:
   OPSMAN_DOMAIN_OR_IP_ADDRESS:
+  SKIP_IF_ALREADY_STAGED:
 
 run:
   path: pcf-pipelines/tasks/stage-product/task.sh

--- a/upgrade-buildpacks/pipeline.yml
+++ b/upgrade-buildpacks/pipeline.yml
@@ -146,7 +146,10 @@ jobs:
   - task: stage
     file: pcf-pipelines/tasks/stage-buildpack/task.yml
     params:
-      <<: *cf_api_params
+      <<: &cf_api_params
+        CF_API_URI: {{cf_api_uri}}
+        CF_USERNAME: {{cf_user}}
+        CF_PASSWORD: {{cf_password}}
       BUILDPACK_NAME: binary_buildpack_latest
 
 - name: promote-binary-buildpack
@@ -459,8 +462,3 @@ jobs:
       <<: *cf_api_params
       SOURCE_BUILDPACK_NAME: tc_buildpack_latest
       TARGET_BUILDPACK_NAME: tc_buildpack
-
-cf_api_params: &cf_api_params
-  CF_API_URI: {{cf_api_uri}}
-  CF_USERNAME: {{cf_user}}
-  CF_PASSWORD: {{cf_password}}

--- a/upgrade-tile/pipeline.yml
+++ b/upgrade-tile/pipeline.yml
@@ -96,6 +96,7 @@ jobs:
       OPSMAN_USERNAME: {{opsman_admin_username}}
       OPSMAN_PASSWORD: {{opsman_admin_password}}
       OPSMAN_DOMAIN_OR_IP_ADDRESS: {{opsman_domain_or_ip_address}}
+      SKIP_IF_ALREADY_STAGED: no
 
   - task: toggle-errands
     file: pcf-pipelines/tasks/toggle-errands/task.yml


### PR DESCRIPTION
* A short explanation of the proposed change: 

Provide a flag that prevents false positives on the tile upgrade.

* An explanation of the use cases your change solves: 

When a tile has an upgrade pipeline, but the version has been updated manually for some reason, the pipeline would keep failing until a new version of the tile is published.

* Expected result after the change: 

When the operator sets the `SKIP_IF_ALREADY_STAGED` param for the `stage-tile` job to `yes`, and the latest matching tile version matches the version of the tile that has been manually installed, the upgrade pipeline does not fail, and does not attempt the upgrade.

* Current result before the change:

When the newest available matching tile version coincides with the version currently installed, the pipeline would invariably fail.

* Links to any other associated PRs or issues:

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests 
