### PR TITLE
Stop allowing the entire internet access to the db

### DIFF
--- a/install-pcf/gcp/terraform/sql.tf
+++ b/install-pcf/gcp/terraform/sql.tf
@@ -30,10 +30,6 @@ resource "google_sql_database_instance" "master" {
           name  = "opsman"
           value = "${google_compute_instance.ops-manager.network_interface.0.access_config.0.assigned_nat_ip}"
         },
-        {
-          name  = "all"
-          value = "0.0.0.0/0"
-        },
       ]
     }
   }


### PR DESCRIPTION
As a part of working with the doc team on the GCP setup instructions, we
are recommending that this setting is removed. All the PCF components
can communicate with Cloud SQL via the NATs and therefore this is not
necessary and is insecure.

Thanks for submitting an pull request to pcf-pipelines.

To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves:

* Expected result after the change:

* Current result before the change:

* Links to any other associated PRs or issues:

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests 
