### PR TITLE
Add option to enable AWS s3 versioning

### DIFF
--- a/install-pcf/aws/params.yml
+++ b/install-pcf/aws/params.yml
@@ -19,6 +19,9 @@ aws_key_name: CHANGEME
 
 aws_region: us-east-1
 
+# Enable or disable s3 versioning, once enabled versioning can't be disabled
+enable_s3_versioning: false
+
 # Ciphers
 # An ordered, colon-delimited list of Golang supported TLS cipher suites in OpenSSL format.
 # Operators should verify that these are supported by any clients or downstream components that will initiate TLS handshakes with the Router/HAProxy.

--- a/install-pcf/aws/pipeline.yml
+++ b/install-pcf/aws/pipeline.yml
@@ -127,6 +127,7 @@ jobs:
       nat_ip_az3: {{nat_ip_az3}}
       OPSMAN_ALLOW_SSH_CIDR_RANGES: {{opsman_allow_ssh_cidr_ranges}}
       OPSMAN_ALLOW_HTTPS_CIDR_RANGES: {{opsman_allow_https_cidr_ranges}}
+      enable_s3_versioning: {{enable_s3_versioning}}
     ensure:
       put: terraform-state
       params:

--- a/install-pcf/aws/tasks/prepare-aws/task.sh
+++ b/install-pcf/aws/tasks/prepare-aws/task.sh
@@ -63,6 +63,7 @@ terraform plan \
   -var "nat_ip_az1=${nat_ip_az1}" \
   -var "nat_ip_az2=${nat_ip_az2}" \
   -var "nat_ip_az3=${nat_ip_az3}" \
+  -var "enable_s3_versioning=${enable_s3_versioning}" \
   -out terraform.tfplan \
   pcf-pipelines/install-pcf/aws/terraform
 

--- a/install-pcf/aws/tasks/prepare-aws/task.yml
+++ b/install-pcf/aws/tasks/prepare-aws/task.yml
@@ -6,7 +6,7 @@ image_resource:
   source:
     repository: pcfnorm/rootfs
 inputs:
-  - name: pcf-pipelines 
+  - name: pcf-pipelines
   - name: terraform-state
   - name: ami
 outputs:
@@ -50,5 +50,7 @@ params:
   nat_ip_az3:
   OPSMAN_ALLOW_SSH_CIDR_RANGES:
   OPSMAN_ALLOW_HTTPS_CIDR_RANGES:
+  enable_s3_versioning:
+
 run:
   path: pcf-pipelines/install-pcf/aws/tasks/prepare-aws/task.sh

--- a/install-pcf/aws/tasks/wipe-env/task.sh
+++ b/install-pcf/aws/tasks/wipe-env/task.sh
@@ -84,5 +84,6 @@ terraform destroy \
   -var "nat_ip_az1=dontcare" \
   -var "nat_ip_az2=dontcare" \
   -var "nat_ip_az3=dontcare" \
+  -var "enable_s3_versioning=true" \
   -state "${root}/terraform-state/terraform.tfstate" \
   -state-out "${root}/terraform-state-output/terraform.tfstate"

--- a/install-pcf/aws/terraform/s3.tf
+++ b/install-pcf/aws/terraform/s3.tf
@@ -7,6 +7,10 @@ resource "aws_s3_bucket" "bosh" {
         Name = "${var.prefix}-bosh"
         Environment = "${var.prefix}"
     }
+
+    versioning {
+      enabled = "${var.enable_s3_versioning}"
+    }
 }
 
 resource "aws_s3_bucket" "buildpacks" {
@@ -17,6 +21,10 @@ resource "aws_s3_bucket" "buildpacks" {
     tags {
         Name = "${var.prefix}-buildpacks"
         Environment = "${var.prefix}"
+    }
+
+    versioning {
+      enabled = "${var.enable_s3_versioning}"
     }
 }
 
@@ -29,6 +37,10 @@ resource "aws_s3_bucket" "droplets" {
         Name = "${var.prefix}-droplets"
         Environment = "${var.prefix}"
     }
+
+    versioning {
+      enabled = "${var.enable_s3_versioning}"
+    }
 }
 
 resource "aws_s3_bucket" "packages" {
@@ -40,6 +52,10 @@ resource "aws_s3_bucket" "packages" {
         Name = "${var.prefix}-packages"
         Environment = "${var.prefix}"
     }
+
+    versioning {
+      enabled = "${var.enable_s3_versioning}"
+    }
 }
 
 resource "aws_s3_bucket" "resources" {
@@ -50,5 +66,9 @@ resource "aws_s3_bucket" "resources" {
     tags {
         Name = "${var.prefix}-resources"
         Environment = "${var.prefix}"
+    }
+
+    versioning {
+      enabled = "${var.enable_s3_versioning}"
     }
 }

--- a/install-pcf/aws/terraform/variables.tf
+++ b/install-pcf/aws/terraform/variables.tf
@@ -12,6 +12,7 @@ variable "aws_az1" {}
 variable "aws_az2" {}
 variable "aws_az3" {}
 variable "route53_zone_id" {}
+variable "enable_s3_versioning" {}
 
 /*
 * used for configuring ingress rules to ops manager vm
@@ -45,6 +46,7 @@ variable "vpc_cidr" {
     description = "CIDR for the whole VPC"
     default = "10.0.0.0/16"
 }
+
 /*
   Availability Zone 1
 */
@@ -154,4 +156,3 @@ variable "infra_subnet_cidr_az1" {
 variable "nat_ip_az3" {
     default = "10.0.2.6"
 }
-


### PR DESCRIPTION
Thanks for submitting an pull request to pcf-pipelines.

To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

   This PR adds option `enable_s3_versioning` to enable versioning for AWS s3 buckets using terraform templates.

* An explanation of the use cases your change solves:

   BBR backups support both [versioned and unversioned](https://docs.pivotal.io/pivotalcf/2-2/customizing/backup-restore/enabling-external-blobstore-backups.html) s3 buckets, to enable versioning it adds a manual task to enable versioning for each bucket from UI/ AWS cli. 

   Using this flag in pipeline will save that additional manual task time. 

* Expected result after the change:
   By default versioning will be disabled, can be switched using the flag.

```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ aws_s3_bucket.bosh
      versioning.0.enabled: "false" => "true"

  ~ aws_s3_bucket.buildpacks
      versioning.0.enabled: "false" => "true"

  ~ aws_s3_bucket.droplets
      versioning.0.enabled: "false" => "true"

  ~ aws_s3_bucket.packages
      versioning.0.enabled: "false" => "true"

  ~ aws_s3_bucket.resources
      versioning.0.enabled: "false" => "true"


Plan: 0 to add, 5 to change, 0 to destroy.

------------------------------------------------------------------------
```

* Current result before the change:

  Versioning is disabled by default for all buckets

* Links to any other associated PRs or issues:

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests 
