### PR TITLE
Move declarations of anchors to get tests to pass

### DIFF
--- a/ci/pcf-pipelines/pipeline.yml
+++ b/ci/pcf-pipelines/pipeline.yml
@@ -105,6 +105,28 @@ groups:
   - trigger-install-pcf-aws
   - final-wipe-aws
 
+atc_creds: &atc_creds
+  ATC_EXTERNAL_URL: {{atc_external_url}}
+  ATC_BASIC_AUTH_USERNAME: {{fly_basic_auth_username}}
+  ATC_BASIC_AUTH_PASSWORD: {{fly_basic_auth_password}}
+  ATC_TEAM_NAME: {{atc_team_name}}
+
+vsphere_atc_creds: &vsphere_atc_creds
+  ATC_EXTERNAL_URL: {{atc_external_url}}
+  ATC_BASIC_AUTH_USERNAME: {{fly_basic_auth_username}}
+  ATC_BASIC_AUTH_PASSWORD: {{fly_basic_auth_password}}
+  ATC_TEAM_NAME: vsphere
+
+notify_slack: &notify_slack
+  put: slack
+  params:
+    text: "$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME failed: $ATC_EXTERNAL_URL/builds/$BUILD_ID"
+
+norm-ci-locks-params: &norm-ci-locks-params
+  uri: git@github.com:pivotal-cf/norm-ci-locks.git
+  branch: master
+  private_key: {{locks_git_ssh_key}}
+  retry_delay: 1m
 
 resource_types:
 - name: smuggler
@@ -1304,26 +1326,3 @@ jobs:
   on_failure:
     <<: *notify_slack
 ####### END VSPHERE OFFLINE
-
-atc_creds: &atc_creds
-  ATC_EXTERNAL_URL: {{atc_external_url}}
-  ATC_BASIC_AUTH_USERNAME: {{fly_basic_auth_username}}
-  ATC_BASIC_AUTH_PASSWORD: {{fly_basic_auth_password}}
-  ATC_TEAM_NAME: {{atc_team_name}}
-
-vsphere_atc_creds: &vsphere_atc_creds
-  ATC_EXTERNAL_URL: {{atc_external_url}}
-  ATC_BASIC_AUTH_USERNAME: {{fly_basic_auth_username}}
-  ATC_BASIC_AUTH_PASSWORD: {{fly_basic_auth_password}}
-  ATC_TEAM_NAME: vsphere
-
-notify_slack: &notify_slack
-  put: slack
-  params:
-    text: "$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME failed: $ATC_EXTERNAL_URL/builds/$BUILD_ID"
-
-norm-ci-locks-params: &norm-ci-locks-params
-  uri: git@github.com:pivotal-cf/norm-ci-locks.git
-  branch: master
-  private_key: {{locks_git_ssh_key}}
-  retry_delay: 1m

--- a/upgrade-buildpacks/pipeline.yml
+++ b/upgrade-buildpacks/pipeline.yml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cf_api_params: &cf_api_params
+  CF_API_URI: {{cf_api_uri}}
+  CF_USERNAME: {{cf_user}}
+  CF_PASSWORD: {{cf_password}}
+
 resource_types:
 - name: pivnet
   type: docker-image
@@ -459,8 +464,3 @@ jobs:
       <<: *cf_api_params
       SOURCE_BUILDPACK_NAME: tc_buildpack_latest
       TARGET_BUILDPACK_NAME: tc_buildpack
-
-cf_api_params: &cf_api_params
-  CF_API_URI: {{cf_api_uri}}
-  CF_USERNAME: {{cf_user}}
-  CF_PASSWORD: {{cf_password}}


### PR DESCRIPTION
Thanks for submitting an pull request to pcf-pipelines.

To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Moving declarations of anchors in `ci/pcf-pipelines/pipeline.yml` and `upgrade-buildpacks/pipeline.yml` to the top of each file.

* An explanation of the use cases your change solves:
Tests will fail when run locally because they reference anchors that have not been declared yet.

* Expected result after the change:
All tests pass.

* Current result before the change:
When running `ginkgo -r -p` in `pcf-pipelines`:
```
• Failure [0.003 seconds]
pcf-pipelines
.../pcf-pipelines/pcf_pipelines_test.go:21
  pipeline at ci/pcf-pipelines/pipeline.yml
 .../pcf-pipelines/pcf_pipelines_test.go:53
    specifies only valid job names in any `passed` definitions in the buildplan [It]
    .../pcf-pipelines/pcf_pipelines_test.go:62

    Expected error:
        <*errors.errorString | 0xc0004523c0>: {
            s: "yaml: unknown anchor 'norm-ci-locks-params' referenced",
        }
        yaml: unknown anchor 'norm-ci-locks-params' referenced
    not to have occurred

    .../pcf-pipelines/pcf_pipelines_test.go:66

<several other similar errors for unknown anchors of other names>
```

* Links to any other associated PRs or issues:

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests 
