### PR TITLE
Upgrade buildpacks for multiple stacks

### DIFF
--- a/ci/pcf-pipelines/pipeline.yml
+++ b/ci/pcf-pipelines/pipeline.yml
@@ -1,3 +1,26 @@
+atc_creds: &atc_creds
+  ATC_EXTERNAL_URL: {{atc_external_url}}
+  ATC_BASIC_AUTH_USERNAME: {{fly_basic_auth_username}}
+  ATC_BASIC_AUTH_PASSWORD: {{fly_basic_auth_password}}
+  ATC_TEAM_NAME: {{atc_team_name}}
+
+vsphere_atc_creds: &vsphere_atc_creds
+  ATC_EXTERNAL_URL: {{atc_external_url}}
+  ATC_BASIC_AUTH_USERNAME: {{fly_basic_auth_username}}
+  ATC_BASIC_AUTH_PASSWORD: {{fly_basic_auth_password}}
+  ATC_TEAM_NAME: vsphere
+
+notify_slack: &notify_slack
+  put: slack
+  params:
+    text: "$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME failed: $ATC_EXTERNAL_URL/builds/$BUILD_ID"
+
+norm-ci-locks-params: &norm-ci-locks-params
+  uri: git@github.com:pivotal-cf/norm-ci-locks.git
+  branch: master
+  private_key: {{locks_git_ssh_key}}
+  retry_delay: 1m
+
 groups:
 - name: all
   jobs:
@@ -1304,26 +1327,3 @@ jobs:
   on_failure:
     <<: *notify_slack
 ####### END VSPHERE OFFLINE
-
-atc_creds: &atc_creds
-  ATC_EXTERNAL_URL: {{atc_external_url}}
-  ATC_BASIC_AUTH_USERNAME: {{fly_basic_auth_username}}
-  ATC_BASIC_AUTH_PASSWORD: {{fly_basic_auth_password}}
-  ATC_TEAM_NAME: {{atc_team_name}}
-
-vsphere_atc_creds: &vsphere_atc_creds
-  ATC_EXTERNAL_URL: {{atc_external_url}}
-  ATC_BASIC_AUTH_USERNAME: {{fly_basic_auth_username}}
-  ATC_BASIC_AUTH_PASSWORD: {{fly_basic_auth_password}}
-  ATC_TEAM_NAME: vsphere
-
-notify_slack: &notify_slack
-  put: slack
-  params:
-    text: "$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME failed: $ATC_EXTERNAL_URL/builds/$BUILD_ID"
-
-norm-ci-locks-params: &norm-ci-locks-params
-  uri: git@github.com:pivotal-cf/norm-ci-locks.git
-  branch: master
-  private_key: {{locks_git_ssh_key}}
-  retry_delay: 1m

--- a/tasks/promote-buildpack/task.sh
+++ b/tasks/promote-buildpack/task.sh
@@ -19,20 +19,23 @@ set -eu
 cf api $CF_API_URI --skip-ssl-validation
 cf auth $CF_USERNAME $CF_PASSWORD
 
-echo Enabling buildpack ${SOURCE_BUILDPACK_NAME}...
-cf update-buildpack $SOURCE_BUILDPACK_NAME --enable
+for STACK_NAME in $STACKS;
+do
+    echo Enabling buildpack ${SOURCE_BUILDPACK_NAME} ${STACK_NAME}...
+    cf update-buildpack $SOURCE_BUILDPACK_NAME -s $STACK_NAME --enable
 
-set +e
-old_buildpack=$(cf buildpacks | grep "${TARGET_BUILDPACK_NAME}\s")
-set -e
-if [ -n "$old_buildpack" ]; then
-  index=$(echo $old_buildpack | cut -d' ' -f2)
-  name=$(echo $old_buildpack | cut -d' ' -f1)
+    set +e
+    old_buildpack=$(cf buildpacks | grep "${TARGET_BUILDPACK_NAME}\s" | grep "${STACK_NAME}")
+    set -e
+    if [ -n "$old_buildpack" ]; then
+      index=$(echo $old_buildpack | cut -d' ' -f2)
+      name=$(echo $old_buildpack | cut -d' ' -f1)
 
-  cf delete-buildpack -f $TARGET_BUILDPACK_NAME
+      cf delete-buildpack -f $TARGET_BUILDPACK_NAME -s $STACK_NAME
 
-  echo Updating buildpack ${SOURCE_BUILDPACK_NAME} index...
-  cf update-buildpack $SOURCE_BUILDPACK_NAME -i $index
-fi
+      echo Updating buildpack ${SOURCE_BUILDPACK_NAME} ${STACK_NAME} index...
+      cf update-buildpack $SOURCE_BUILDPACK_NAME -s $STACK_NAME -i $index
+    fi
 
-cf rename-buildpack $SOURCE_BUILDPACK_NAME $TARGET_BUILDPACK_NAME
+    cf rename-buildpack $SOURCE_BUILDPACK_NAME $TARGET_BUILDPACK_NAME -s $STACK_NAME
+done

--- a/tasks/promote-buildpack/task.yml
+++ b/tasks/promote-buildpack/task.yml
@@ -19,6 +19,7 @@ image_resource:
   type: docker-image
   source:
     repository: pcfnorm/rootfs
+    tag: 1.0.28
 
 
 inputs:

--- a/tasks/promote-buildpack/task.yml
+++ b/tasks/promote-buildpack/task.yml
@@ -30,6 +30,7 @@ params:
   CF_PASSWORD:
   SOURCE_BUILDPACK_NAME:
   TARGET_BUILDPACK_NAME:
+  STACKS:
 
 run:
   path: pcf-pipelines/tasks/promote-buildpack/task.sh

--- a/tasks/stage-buildpack/task.sh
+++ b/tasks/stage-buildpack/task.sh
@@ -19,14 +19,18 @@ set -eu
 cf api $CF_API_URI --skip-ssl-validation
 cf auth $CF_USERNAME $CF_PASSWORD
 
-set +e
-existing_buildpack=$(cf buildpacks | grep "${BUILDPACK_NAME}\s")
-set -e
-if [ -z "${existing_buildpack}" ]; then
-  COUNT=$(cf buildpacks | grep --regexp=".zip" --count)
-  NEW_POSITION=$(expr $COUNT + 1)
-  cf create-buildpack $BUILDPACK_NAME buildpack/*.zip $NEW_POSITION --enable
-else
-  index=$(echo $existing_buildpack | cut -d' ' -f2)
-  cf update-buildpack $BUILDPACK_NAME -p buildpack/*.zip -i $index --enable
-fi
+
+for STACK_NAME in $STACKS;
+do
+    set +e
+    existing_buildpack=$(cf buildpacks | grep "${BUILDPACK_NAME}\s" | grep "${STACK_NAME}")
+    set -e
+    if [ -z "${existing_buildpack}" ]; then
+      COUNT=$(cf buildpacks | grep --regexp=".zip" --count)
+      NEW_POSITION=$(expr $COUNT + 1)
+      cf create-buildpack $BUILDPACK_NAME buildpack/*-$STACK_NAME-*.zip $NEW_POSITION --enable
+    else
+      index=$(echo $existing_buildpack | cut -d' ' -f2)
+      cf update-buildpack $BUILDPACK_NAME -p buildpack/*-$STACK_NAME-*.zip -s $STACK_NAME -i $index --enable
+    fi
+done

--- a/tasks/stage-buildpack/task.yml
+++ b/tasks/stage-buildpack/task.yml
@@ -19,6 +19,7 @@ image_resource:
   type: docker-image
   source:
     repository: pcfnorm/rootfs
+    tag: 1.0.28
 
 
 inputs:

--- a/tasks/stage-buildpack/task.yml
+++ b/tasks/stage-buildpack/task.yml
@@ -30,6 +30,7 @@ params:
   CF_USERNAME:
   CF_PASSWORD:
   BUILDPACK_NAME:
+  STACKS:
 
 run:
   path: pcf-pipelines/tasks/stage-buildpack/task.sh

--- a/tasks/upgrade-buildpack/task.sh
+++ b/tasks/upgrade-buildpack/task.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu
+
+# Copyright 2017-Present Pivotal Software, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cf api $CF_API_URI --skip-ssl-validation
+cf auth $CF_USERNAME $CF_PASSWORD
+
+for STACK_NAME in $STACKS;
+do
+    echo Upgrading ${TARGET_BUILDPACK_NAME} ${STACK_NAME}...
+    cf update-buildpack $TARGET_BUILDPACK_NAME -s $STACK_NAME -p buildpack/*.zip --enable
+done

--- a/tasks/upgrade-buildpack/task.yml
+++ b/tasks/upgrade-buildpack/task.yml
@@ -19,6 +19,7 @@ image_resource:
   type: docker-image
   source:
     repository: pcfnorm/rootfs
+    tag: 1.0.28
 
 
 inputs:

--- a/tasks/upgrade-buildpack/task.yml
+++ b/tasks/upgrade-buildpack/task.yml
@@ -1,0 +1,36 @@
+# Copyright 2017-Present Pivotal Software, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: pcfnorm/rootfs
+
+
+inputs:
+- name: buildpack
+- name: pcf-pipelines
+
+params:
+  CF_API_URI:
+  CF_USERNAME:
+  CF_PASSWORD:
+  TARGET_BUILDPACK_NAME:
+  STACKS:
+
+run:
+  path: pcf-pipelines/tasks/upgrade-buildpack/task.sh

--- a/upgrade-buildpacks/pipeline.yml
+++ b/upgrade-buildpacks/pipeline.yml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cf_api_params: &cf_api_params
+  CF_API_URI: {{cf_api_uri}}
+  CF_USERNAME: {{cf_user}}
+  CF_PASSWORD: {{cf_password}}
+
 resource_types:
 - name: pivnet
   type: docker-image
@@ -31,71 +36,71 @@ resources:
   type: pivnet
   source:
     api_token: {{pivnet_token}}
-    product_slug: buildpacks
-    product_version: Binary*
+    product_slug: binary-buildpack
+    product_version: \d+\.\d+\.\d+
 
 - name: dotnet-core-buildpack
   type: pivnet
   source:
     api_token: {{pivnet_token}}
-    product_slug: buildpacks
-    product_version: \.NET*
+    product_slug: dotnet-core-buildpack
+    product_version: \d+\.\d+\.\d+
 
 - name: go-buildpack
   type: pivnet
   source:
     api_token: {{pivnet_token}}
-    product_slug: buildpacks
-    product_version: ^Go.*
+    product_slug: go-buildpack
+    product_version: \d+\.\d+\.\d+
 
 - name: java-buildpack
   type: pivnet
   source:
     api_token: {{pivnet_token}}
-    product_slug: buildpacks
-    product_version: Java*
+    product_slug: java-buildpack
+    product_version: \d+\.\d+(\.\d+)?
 
 - name: nodejs-buildpack
   type: pivnet
   source:
     api_token: {{pivnet_token}}
-    product_slug: buildpacks
-    product_version: NodeJS*
+    product_slug: nodejs-buildpack
+    product_version: \d+\.\d+\.\d+
 
 - name: php-buildpack
   type: pivnet
   source:
     api_token: {{pivnet_token}}
-    product_slug: buildpacks
-    product_version: PHP*
+    product_slug: php-buildpack
+    product_version: \d+\.\d+\.\d+
 
 - name: python-buildpack
   type: pivnet
   source:
     api_token: {{pivnet_token}}
-    product_slug: buildpacks
-    product_version: Python*
+    product_slug: python-buildpack
+    product_version: \d+\.\d+\.\d+
 
 - name: ruby-buildpack
   type: pivnet
   source:
     api_token: {{pivnet_token}}
-    product_slug: buildpacks
-    product_version: Ruby*
+    product_slug: ruby-buildpack
+    product_version: \d+\.\d+\.\d+
 
 - name: staticfile-buildpack
   type: pivnet
   source:
     api_token: {{pivnet_token}}
-    product_slug: buildpacks
-    product_version: Staticfile*
+    product_slug: staticfile-buildpack
+    product_version: \d+\.\d+\.\d+
 
 - name: tc-buildpack
   type: pivnet
   source:
     api_token: {{pivnet_token}}
-    product_slug: buildpacks
-    product_version: "tc Server*"
+    product_slug: tc-server-buildpack
+    product_version: \d+\.\d+(\.\d+)?
 
 - name: schedule
   type: time
@@ -148,6 +153,7 @@ jobs:
     params:
       <<: *cf_api_params
       BUILDPACK_NAME: binary_buildpack_latest
+      STACKS: "cflinuxfs2 cflinuxfs3 windows2012R2 windows2016"
 
 - name: promote-binary-buildpack
   serial_groups: [cc-api]
@@ -164,6 +170,7 @@ jobs:
       <<: *cf_api_params
       SOURCE_BUILDPACK_NAME: binary_buildpack_latest
       TARGET_BUILDPACK_NAME: binary_buildpack
+      STACKS: "cflinuxfs2 cflinuxfs3 windows2012R2 windows2016"
 
 - name: stage-dotnet-buildpack
   serial_groups: [cc-api]
@@ -180,6 +187,7 @@ jobs:
     params:
       <<: *cf_api_params
       BUILDPACK_NAME: dotnet_core_buildpack_offline_latest
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: promote-dotnet-buildpack
   serial_groups: [cc-api]
@@ -196,6 +204,7 @@ jobs:
       <<: *cf_api_params
       SOURCE_BUILDPACK_NAME: dotnet_core_buildpack_offline_latest
       TARGET_BUILDPACK_NAME: dotnet_core_buildpack_offline
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: stage-go-buildpack
   serial_groups: [cc-api]
@@ -212,6 +221,7 @@ jobs:
     params:
       <<: *cf_api_params
       BUILDPACK_NAME: go_buildpack_latest
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: promote-go-buildpack
   serial_groups: [cc-api]
@@ -228,6 +238,7 @@ jobs:
       <<: *cf_api_params
       SOURCE_BUILDPACK_NAME: go_buildpack_latest
       TARGET_BUILDPACK_NAME: go_buildpack
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: stage-java-buildpack
   serial_groups: [cc-api]
@@ -247,6 +258,7 @@ jobs:
     params:
       <<: *cf_api_params
       BUILDPACK_NAME: java_buildpack_offline_latest
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: promote-java-buildpack
   serial_groups: [cc-api]
@@ -263,6 +275,7 @@ jobs:
       <<: *cf_api_params
       SOURCE_BUILDPACK_NAME: java_buildpack_offline_latest
       TARGET_BUILDPACK_NAME: java_buildpack_offline
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: stage-nodejs-buildpack
   serial_groups: [cc-api]
@@ -279,6 +292,7 @@ jobs:
     params:
       <<: *cf_api_params
       BUILDPACK_NAME: nodejs_buildpack_latest
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: promote-nodejs-buildpack
   serial_groups: [cc-api]
@@ -295,6 +309,7 @@ jobs:
       <<: *cf_api_params
       SOURCE_BUILDPACK_NAME: nodejs_buildpack_latest
       TARGET_BUILDPACK_NAME: nodejs_buildpack
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: stage-php-buildpack
   serial_groups: [cc-api]
@@ -311,6 +326,7 @@ jobs:
     params:
       <<: *cf_api_params
       BUILDPACK_NAME: php_buildpack_latest
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: promote-php-buildpack
   serial_groups: [cc-api]
@@ -327,6 +343,7 @@ jobs:
       <<: *cf_api_params
       SOURCE_BUILDPACK_NAME: php_buildpack_latest
       TARGET_BUILDPACK_NAME: php_buildpack
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: stage-python-buildpack
   serial_groups: [cc-api]
@@ -343,6 +360,7 @@ jobs:
     params:
       <<: *cf_api_params
       BUILDPACK_NAME: python_buildpack_latest
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: promote-python-buildpack
   serial_groups: [cc-api]
@@ -359,6 +377,7 @@ jobs:
       <<: *cf_api_params
       SOURCE_BUILDPACK_NAME: python_buildpack_latest
       TARGET_BUILDPACK_NAME: python_buildpack
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: stage-ruby-buildpack
   serial_groups: [cc-api]
@@ -375,6 +394,7 @@ jobs:
     params:
       <<: *cf_api_params
       BUILDPACK_NAME: ruby_buildpack_latest
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: promote-ruby-buildpack
   serial_groups: [cc-api]
@@ -391,6 +411,7 @@ jobs:
       <<: *cf_api_params
       SOURCE_BUILDPACK_NAME: ruby_buildpack_latest
       TARGET_BUILDPACK_NAME: ruby_buildpack
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: stage-staticfile-buildpack
   serial_groups: [cc-api]
@@ -407,6 +428,7 @@ jobs:
     params:
       <<: *cf_api_params
       BUILDPACK_NAME: staticfile_buildpack_latest
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: promote-staticfile-buildpack
   serial_groups: [cc-api]
@@ -423,6 +445,7 @@ jobs:
       <<: *cf_api_params
       SOURCE_BUILDPACK_NAME: staticfile_buildpack_latest
       TARGET_BUILDPACK_NAME: staticfile_buildpack
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: stage-tcserver-buildpack
   serial_groups: [cc-api]
@@ -442,6 +465,7 @@ jobs:
     params:
       <<: *cf_api_params
       BUILDPACK_NAME: tc_buildpack_latest
+      STACKS: "cflinuxfs2 cflinuxfs3"
 
 - name: promote-tcserver-buildpack
   serial_groups: [cc-api]
@@ -459,8 +483,4 @@ jobs:
       <<: *cf_api_params
       SOURCE_BUILDPACK_NAME: tc_buildpack_latest
       TARGET_BUILDPACK_NAME: tc_buildpack
-
-cf_api_params: &cf_api_params
-  CF_API_URI: {{cf_api_uri}}
-  CF_USERNAME: {{cf_user}}
-  CF_PASSWORD: {{cf_password}}
+      STACKS: "cflinuxfs2 cflinuxfs3"

--- a/upgrade-buildpacks/pipeline.yml
+++ b/upgrade-buildpacks/pipeline.yml
@@ -240,40 +240,23 @@ jobs:
       TARGET_BUILDPACK_NAME: go_buildpack
       STACKS: "cflinuxfs2 cflinuxfs3"
 
-- name: stage-java-buildpack
+- name: upgrade-java-buildpack
   serial_groups: [cc-api]
   plan:
   - aggregate:
     - get: pcf-pipelines
     - get: buildpack
-      passed: [regulator]
       resource: java-buildpack
+      passed: [regulator]
       trigger: true
       params:
         globs:
         - "*offline*"
 
-  - task: stage
-    file: pcf-pipelines/tasks/stage-buildpack/task.yml
+  - task: upgrade
+    file: pcf-pipelines/tasks/upgrade-buildpack/task.yml
     params:
       <<: *cf_api_params
-      BUILDPACK_NAME: java_buildpack_offline_latest
-      STACKS: "cflinuxfs2 cflinuxfs3"
-
-- name: promote-java-buildpack
-  serial_groups: [cc-api]
-  plan:
-  - aggregate:
-    - get: java-buildpack
-      passed: [stage-java-buildpack]
-      trigger: true
-      params: {globs: []}
-    - get: pcf-pipelines
-  - task: promote
-    file: pcf-pipelines/tasks/promote-buildpack/task.yml
-    params:
-      <<: *cf_api_params
-      SOURCE_BUILDPACK_NAME: java_buildpack_offline_latest
       TARGET_BUILDPACK_NAME: java_buildpack_offline
       STACKS: "cflinuxfs2 cflinuxfs3"
 
@@ -447,40 +430,22 @@ jobs:
       TARGET_BUILDPACK_NAME: staticfile_buildpack
       STACKS: "cflinuxfs2 cflinuxfs3"
 
-- name: stage-tcserver-buildpack
+- name: upgrade-tcserver-buildpack
   serial_groups: [cc-api]
   plan:
   - aggregate:
     - get: pcf-pipelines
     - get: buildpack
-      passed: [regulator]
       resource: tc-buildpack
+      passed: [regulator]
       trigger: true
       params:
         globs:
         - "*offline*"
 
-  - task: stage
-    file: pcf-pipelines/tasks/stage-buildpack/task.yml
+  - task: upgrade
+    file: pcf-pipelines/tasks/upgrade-buildpack/task.yml
     params:
       <<: *cf_api_params
-      BUILDPACK_NAME: tc_buildpack_latest
-      STACKS: "cflinuxfs2 cflinuxfs3"
-
-- name: promote-tcserver-buildpack
-  serial_groups: [cc-api]
-  plan:
-  - aggregate:
-    - get: tc-buildpack
-      passed: [stage-tcserver-buildpack]
-      trigger: true
-      params: {globs: []}
-    - get: pcf-pipelines
-
-  - task: promote
-    file: pcf-pipelines/tasks/promote-buildpack/task.yml
-    params:
-      <<: *cf_api_params
-      SOURCE_BUILDPACK_NAME: tc_buildpack_latest
       TARGET_BUILDPACK_NAME: tc_buildpack
       STACKS: "cflinuxfs2 cflinuxfs3"


### PR DESCRIPTION
**Blockers**:
  Latest `cf cli`: https://github.com/pivotal-cf/pcf-pipelines/issues/373


Modifies the pipelines and tasks for updating PCF buildpacks so that they consume new pivnet buildpack products and associates the newly promoted buildpacks with all compatible stacks.

Changes updating java buildpack task to work around its lack of initial stack association with either the cflinuxfs2 or cflinuxfs3 stack.

[Tracker story #161451869](https://www.pivotaltracker.com/story/show/161451869)

* An explanation of the use cases your change solves:

  - Pivnet now provides buildpacks as individual products and we want to support consuming those products in PCF pipelines in addition to properly associating them with compatible stacks.

  - The `Java buildpack` lacks an initial stack association, and so we have to work around that fact when we  do the upgrade.

* Expected result after the change:
   - New buildpacks that are published via individual Pivnet products are consumed, staged, and promoted with proper stack association.
  - Java buildpack is consumed from pivnet and updated as new versions are released.

* Current result before the change:
  - Monolithic buildpack product on Pivnet is the source of all buildpacks.
  - Buildpacks are not stack associated


* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [x] I have run all the unit tests 
