### PR TITLE
--decryption-passphrase location chance

### DIFF
--- a/tasks/import-opsmgr-settings/task.sh
+++ b/tasks/import-opsmgr-settings/task.sh
@@ -30,9 +30,9 @@ function main() {
   om-linux --target "https://${OPSMAN_DOMAIN_OR_IP_ADDRESS}" \
       --skip-ssl-validation \
       --request-timeout 86400 \
+      --decryption-passphrase "${OPSMAN_PASSPHRASE}" \
       import-installation \
-      --installation "${cwd}/opsmgr-settings/${OPSMAN_SETTINGS_FILENAME}" \
-      --decryption-passphrase "${OPSMAN_PASSPHRASE}"
+      --installation "${cwd}/opsmgr-settings/${OPSMAN_SETTINGS_FILENAME}"
  }
 
  main "${PWD}"


### PR DESCRIPTION
--decryption-passphrase  needs to be set before import-installation for om to work. 

```This unauthenticated command attempts to import an installation to the Ops Manager targeted.

Usage: om [options] import-installation [<args>]
  --client-id, -c, OM_CLIENT_ID                          string  Client ID for the Ops Manager VM (not required for unauthenticated commands)
  --client-secret, -s, OM_CLIENT_SECRET                  string  Client Secret for the Ops Manager VM (not required for unauthenticated commands)
  --connect-timeout, -o                                  int     timeout in seconds to make TCP connections (default: 5)
  --decryption-passphrase, -d, OM_DECRYPTION_PASSPHRASE  string  Passphrase to decrypt the installation if the Ops Manager VM has been rebooted (optional for most commands)
  --env, -e                                              string  env file with login credentials
  --help, -h                                             bool    prints this usage information (default: false)
  --password, -p, OM_PASSWORD                            string  admin password for the Ops Manager VM (not required for unauthenticated commands)
  --request-timeout, -r                                  int     timeout in seconds for HTTP requests to Ops Manager (default: 1800)
  --skip-ssl-validation, -k                              bool    skip ssl certificate validation during http requests (default: false)
  --target, -t, OM_TARGET                                string  location of the Ops Manager VM
  --trace, -tr                                           bool    prints HTTP requests and response payloads
  --username, -u, OM_USERNAME                            string  admin username for the Ops Manager VM (not required for unauthenticated commands)
  --version, -v                                          bool    prints the om release version (default: false)

Command Arguments:
  --config, -c             string             path to yml file for configuration (keys must match the following command line flags)
  --installation, -i       string (required)  path to installation.
  --polling-interval, -pi  int                interval (in seconds) at which to print status (default: 1)```

Thanks for submitting an pull request to pcf-pipelines.

To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves:

* Expected result after the change:

* Current result before the change:

* Links to any other associated PRs or issues:

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests 
