### PR TITLE
Add connect and request timeout configurations.

### DIFF
--- a/tasks/apply-changes/task.sh
+++ b/tasks/apply-changes/task.sh
@@ -25,5 +25,7 @@ om-linux \
   --client-secret "${OPSMAN_CLIENT_SECRET}" \
   --username "${OPSMAN_USERNAME}" \
   --password "${OPSMAN_PASSWORD}" \
+  --connect-timeout ${OPSMAN_CONNECT_TIMEOUT} \
+  --request-timeout ${OPSMAN_REQUEST_TIMEOUT} \
   apply-changes \
   --ignore-warnings

--- a/tasks/apply-changes/task.yml
+++ b/tasks/apply-changes/task.yml
@@ -19,6 +19,7 @@ image_resource:
   type: docker-image
   source:
     repository: pcfnorm/rootfs
+    tag: 1.0.28
 
 
 inputs:
@@ -29,6 +30,8 @@ params:
   OPSMAN_CLIENT_SECRET:
   OPSMAN_USERNAME:
   OPSMAN_PASSWORD:
+  OPSMAN_CONNECT_TIMEOUT: 5
+  OPSMAN_REQUEST_TIMEOUT: 1800
   OPSMAN_DOMAIN_OR_IP_ADDRESS:
 
 run:


### PR DESCRIPTION
In our environment, we have been experiencing several connection related
timeouts while using the om cli utility during the apply-changes task.
As of om 0.37.0, it provides the ability to configure both a connect and
a request timeout. This change allows both of those to be user
configurable within external pipelines.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests 
