### PR TITLE
fix for load balancer mapping in resource_config ERT tile.

### DIFF
--- a/install-pcf/azure/pipeline.yml
+++ b/install-pcf/azure/pipeline.yml
@@ -488,6 +488,7 @@ jobs:
       HAPROXY_FLOATING_IPS: ""
       OPSMAN_CLIENT_ID: ""
       OPSMAN_CLIENT_SECRET: ""
+      AZURE_TERRAFORM_PREFIX: {{azure_terraform_prefix}}
 ###########################
 ## Job - Deploy    ERT   ##
 ###########################

--- a/tasks/config-ert/task.sh
+++ b/tasks/config-ert/task.sh
@@ -538,6 +538,7 @@ cf_resources=$(
     --arg mysql_nsx_lb_pool_name "${MYSQL_NSX_LB_POOL_NAME}" \
     --arg mysql_nsx_lb_security_group "${MYSQL_NSX_LB_SECURITY_GROUP}" \
     --arg mysql_nsx_lb_port "${MYSQL_NSX_LB_PORT}" \
+    --arg AZURE_TERRAFORM_PREFIX "${AZURE_TERRAFORM_PREFIX}" \
     --argjson job_resource_config "${JOB_RESOURCE_CONFIG}" \
     '
     $job_resource_config

--- a/tasks/config-ert/task.sh
+++ b/tasks/config-ert/task.sh
@@ -560,6 +560,15 @@ cf_resources=$(
 
     |
 
+    if $iaas == "azure" then
+      .router |= . + { "elb_names": ["\($AZURE_TERRAFORM_PREFIX)-web-lb"] }
+      | .diego_brain |= . + { "elb_names": ["\($AZURE_TERRAFORM_PREFIX)-ssh-proxy-lb"] }
+    else
+      .
+    end
+
+    |
+
     # NSX LBs
 
     if $tcp_router_nsx_lb_edge_name != "" then

--- a/tasks/config-ert/task.sh
+++ b/tasks/config-ert/task.sh
@@ -538,7 +538,7 @@ cf_resources=$(
     --arg mysql_nsx_lb_pool_name "${MYSQL_NSX_LB_POOL_NAME}" \
     --arg mysql_nsx_lb_security_group "${MYSQL_NSX_LB_SECURITY_GROUP}" \
     --arg mysql_nsx_lb_port "${MYSQL_NSX_LB_PORT}" \
-    --arg AZURE_TERRAFORM_PREFIX "${AZURE_TERRAFORM_PREFIX}" \
+    --arg azure_terraform_prefix "${AZURE_TERRAFORM_PREFIX}" \
     --argjson job_resource_config "${JOB_RESOURCE_CONFIG}" \
     '
     $job_resource_config
@@ -562,8 +562,9 @@ cf_resources=$(
     |
 
     if $iaas == "azure" then
-      .router |= . + { "elb_names": ["\($AZURE_TERRAFORM_PREFIX)-web-lb"] }
-      | .diego_brain |= . + { "elb_names": ["\($AZURE_TERRAFORM_PREFIX)-ssh-proxy-lb"] }
+      .router |= . + { "elb_names": ["\($azure_terraform_prefix)-web-lb"] }
+      | .diego_brain |= . + { "elb_names": ["\($azure_terraform_prefix)-ssh-proxy-lb"] }
+      | .tcp_router |= . + { "elb_names": ["\($azure_terraform_prefix)-tcp-lb"] }
     else
       .
     end

--- a/tasks/config-ert/task.yml
+++ b/tasks/config-ert/task.yml
@@ -131,6 +131,7 @@ params:
   POE_SSL_KEY3:
   OPSMAN_CLIENT_ID:
   OPSMAN_CLIENT_SECRET:
+  AZURE_TERRAFORM_PREFIX:
 
 inputs:
   - name: pcf-pipelines


### PR DESCRIPTION
Hi, 

This fix is for load balancer mapping in resource_config ERT tile.
following lb will be configured in "configure-ert" job in install-pcf pipeline.
router-web-lb, ssh-proxy-lb, tcp_router-lb in configure-ert  for PCF 2.4.x on azure
this PR has been tested on azure.

