### PR TITLE
don't be so greedy

### DIFF
--- a/upgrade-ops-manager/gcp/tasks/create-cliaas-config/task.sh
+++ b/upgrade-ops-manager/gcp/tasks/create-cliaas-config/task.sh
@@ -20,7 +20,7 @@ cat > cliaas-config/gcpcreds.json <<EOF
 ${GCP_SERVICE_ACCOUNT_KEY}
 EOF
 
-DISK_IMAGE_PATH=$(grep ${PIVNET_IMAGE_REGION} pivnet-opsmgr/*GCP.yml | awk '{split($0, a); print a[2]}')
+DISK_IMAGE_PATH=$(grep -m1 ${PIVNET_IMAGE_REGION} pivnet-opsmgr/*GCP.yml | awk '{split($0, a); print a[2]}')
 if [ -z "DISK_IMAGE_PATH" ]; then
   echo Could not find disk image for region \"PIVNET_IMAGE_REGION\". Available choices are:
   cat pivnet-opsmgr/*GCP.yml | cut -f1 -d':'


### PR DESCRIPTION
Thanks for submitting an pull request to pcf-pipelines.

To speed up the process of reviewing your pull request please provide us with:

* Recently there has been some format changes in the pivnet yaml file for GCP where the opsman tarball is located under the US directory for all regions example: 

OpsMan 2.4

$> cat OpsManager2.4-build.192onGCP.yml

us: ops-manager-us/pcf-gcp-2.4-build.192.tar.gz
eu: ops-manager-us/pcf-gcp-2.4-build.192.tar.gz
asia: ops-manager-us/pcf-gcp-2.4-build.192.tar.gz

This results in grep matching more then one occurrence of the pattern.  This leads to the following incorrect new yml file from being created.

disk_image_url: ops-manager-us/pcf-gcp-2.3-build.305.tar.gz
ops-manager-us/pcf-gcp-2.3-build.305.tar.gz
ops-manager-us/pcf-gcp-2.3-build.305.tar.gz

Notice the 2 additional values being inserted in the key value pair.

The proposed pull request would limit the regex matching to one occurrence, when grep is run.  
